### PR TITLE
Fix Higheq ingestion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,13 @@ backup.prod::
 adminer::
 	open http://localhost:40222/?pgsql=db&username=postgres
 
+reset-database::
+	PGPASSWORD=example psql \
+		-U postgres \
+		-d postgres \
+		-p 40111 \
+		-h 127.0.0.1 \
+		-c "drop schema public cascade; create schema public;"
+
 psql::
 	psql postgresql://postgres:example@localhost:40111/ddex1

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Audius DDEX Processor
 
-This is a node.js program + webapp to ingest DDEX files and publish them to Audius.
+A node.js program + webapp to ingest DDEX files and publish them to Audius.
+
+
 You configure multiple sources (in `data/sources.json`) and point them to S3 buckets.
 The crawler will look for new XML files in the S3 buckets, parse the details and publish the music if preconditions are met.
-To publish to Audius currently, it requires the artist account authorizes the source keypair to publish on their behalf.
-This is done using the [Audius SDK oauth method](https://docs.audius.org/developers/sdk/oauth).
+
+Tracks are either
+1. Published automatically to an artist profile that authorizes the source keypair to distribute on their behalf. This is done using the [Audius SDK oauth method](https://docs.audius.org/developers/sdk/oauth).
+2. Published manually using the UI tools provided in this package
+
 
 * See [README_DEV](./README_DEV.md) for dev setup.
 * See [README_PROD](./README_PROD.md) for prod setup.

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -3,7 +3,7 @@
 Install + run tests:
 
 ```bash
-docker compose up
+docker compose up -d
 
 npm i
 make test
@@ -17,6 +17,8 @@ NODE_ENV = 'staging'
 DDEX_URL = 'https://localhost:8989'
 ADMIN_HANDLES = 'user1,user2'
 SKIP_SDK_PUBLISH='true'
+DB_URL='postgresql://postgres:example@127.0.0.1:40111/postgres'
+DISCOVERY_DB=
 ```
 
 Create `data/sources.json` file like:
@@ -52,11 +54,18 @@ npm run dev
 - do oauth
 - visit http://localhost:8989/releases - see two releases from initial CLI run above
 
-If you have setup an S3 source in `data/sources.json`... you can run worker to crawl buckets and see results locally:
+If you have setup an S3 source in `data/sources.json`, you can run the worker to crawl buckets and see results locally:
 
 ```bash
-npx tsx cli worker
+npm run worker
 ```
+
+If you want to delete the state and re-crawl from the start
+
+```bash
+make reset-database
+```
+
 
 ---
 

--- a/src/parseDelivery.ts
+++ b/src/parseDelivery.ts
@@ -480,6 +480,7 @@ async function parseReleaseXml(source: string, $: cheerio.CheerioAPI) {
   $('ResourceList > Image')
     .toArray()
     .reduce(ddexResourceReducer, imageResources)
+  console.log('imageResources', imageResources)
 
   $('ResourceList > Text').toArray().reduce(ddexResourceReducer, textResources)
 

--- a/src/parseDelivery.ts
+++ b/src/parseDelivery.ts
@@ -480,7 +480,6 @@ async function parseReleaseXml(source: string, $: cheerio.CheerioAPI) {
   $('ResourceList > Image')
     .toArray()
     .reduce(ddexResourceReducer, imageResources)
-  console.log('imageResources', imageResources)
 
   $('ResourceList > Text').toArray().reduce(ddexResourceReducer, textResources)
 

--- a/src/reporting/lsr_reader.ts
+++ b/src/reporting/lsr_reader.ts
@@ -19,7 +19,16 @@ type LsrRow = {
 }
 
 export async function pollForNewLSRFiles() {
-  const { mri } = sources.reporting()
+  const reporting = sources.reporting()
+  if (!reporting) {
+    console.log('No reporting source found')
+    return
+  }
+  const { mri } = reporting
+  if (!mri) {
+    console.log('No MRI source found')
+    return
+  }
   const client = dialS3(mri)
   const bucket = mri.awsBucket
   const result = await client.send(

--- a/src/s3poller.ts
+++ b/src/s3poller.ts
@@ -69,7 +69,6 @@ export async function pollS3Source(
         Marker,
       })
     )
-    console.log(result)
     
     const prefixes = result.CommonPrefixes?.map((p) => p.Prefix).filter(
       Boolean

--- a/src/s3poller.ts
+++ b/src/s3poller.ts
@@ -69,51 +69,65 @@ export async function pollS3Source(
         Marker,
       })
     )
+    console.log(result)
+    
     const prefixes = result.CommonPrefixes?.map((p) => p.Prefix).filter(
       Boolean
     ) as string[]
+    
     console.log(
-      `polling s3 ${bucket} from ${Marker} got ${prefixes?.length} items`
+      `polling s3 ${bucket} from ${Marker} got ${prefixes?.length || 0} prefixes and ${result.Contents?.length || 0} files`
     )
-    if (!prefixes) {
+
+    // Handle case where there are common prefixes (folder structure)
+    if (prefixes && prefixes.length > 0) {
+      const batchSize = 20
+      for (let i = 0; i < prefixes.length; i += batchSize) {
+        const batch = prefixes.slice(i, i + batchSize)
+        await Promise.all(
+          batch.map(async (prefix) => {
+            await scanS3Prefix(sourceName, client, bucket, prefix)
+          })
+        )
+      }
+      
+      // save marker for prefixes
+      Marker = prefixes.at(-1)!
+      console.log('update marker', { bucket, Marker })
+      await s3markerRepo.upsert(bucket, Marker)
+    }
+    // Handle case where files are at root level (no prefixes)
+    else if (result.Contents && result.Contents.length > 0) {
+      // Process files directly at root level using the same logic
+      await processS3Contents(sourceName, client, bucket, result.Contents)
+
+      // Update marker to last processed file key
+      const lastKey = result.Contents.at(-1)?.Key
+      if (lastKey) {
+        console.log('update marker', { bucket, Marker: lastKey })
+        await s3markerRepo.upsert(bucket, lastKey)
+      }
+
+      // Break if not truncated (no more files)
+      if (!result.IsTruncated) {
+        break
+      }
+    }
+    else {
+      // No prefixes and no contents, we're done
       break
     }
-
-    const batchSize = 20
-    for (let i = 0; i < prefixes.length; i += batchSize) {
-      const batch = prefixes.slice(i, i + batchSize)
-      await Promise.all(
-        batch.map(async (prefix) => {
-          await scanS3Prefix(sourceName, client, bucket, prefix)
-        })
-      )
-    }
-
-    // save marker
-    Marker = prefixes.at(-1)!
-    console.log('update marker', { bucket, Marker })
-    await s3markerRepo.upsert(bucket, Marker)
   }
 }
 
-// recursively scan a prefix for xml files
-async function scanS3Prefix(
+// Helper function to process S3 objects (XML files)
+async function processS3Contents(
   source: string,
   client: S3Client,
   bucket: string,
-  prefix: string
+  contents: any[]
 ) {
-  const result = await client.send(
-    new ListObjectsCommand({
-      Bucket: bucket,
-      Prefix: prefix,
-    })
-  )
-  if (!result.Contents?.length) {
-    return
-  }
-
-  for (const c of result.Contents) {
+  for (const c of contents) {
     if (!c.Key) continue
 
     const lowerKey = c.Key.toLowerCase()
@@ -134,6 +148,26 @@ async function scanS3Prefix(
       const releases = (await parseDdexXml(source, xmlUrl, xml)) || []
     }
   }
+}
+
+// recursively scan a prefix for xml files
+async function scanS3Prefix(
+  source: string,
+  client: S3Client,
+  bucket: string,
+  prefix: string
+) {
+  const result = await client.send(
+    new ListObjectsCommand({
+      Bucket: bucket,
+      Prefix: prefix,
+    })
+  )
+  if (!result.Contents?.length) {
+    return
+  }
+
+  await processS3Contents(source, client, bucket, result.Contents)
 }
 
 //


### PR DESCRIPTION
- Handle parsing with no prefixes (tested higheq + toolroom to make sure it's all still working)
- make reset-database command (is there something better you use?)
- make it so you don't need to define reporting info in sources.json for things to work
- Add `npm run worker` so you don't have to npx tsx manually