### PR TITLE
[API-212] Add AcknowledgementMessage support

### DIFF
--- a/src/acknowledgement.ts
+++ b/src/acknowledgement.ts
@@ -104,15 +104,19 @@ function getSourcePartyName(source: string): string {
   }
 }
 
-function generateAcknowledgementXml(
+function generateAcknowledgementXml({
+  source,
+  messageId,
+  releases,
+  isSuccess,
+  error,
+}: {
   source: string,
-  xmlUrl: string,
   messageId: string,
-  messageTimestamp: string,
   releases: DDEXRelease[],
   isSuccess: boolean,
   error?: string
-): string {
+}): string {
   const $ = cheerio.load('', { xmlMode: true })
   
   // Create root element
@@ -269,13 +273,19 @@ async function sendAcknowledgement(source: string, xml: string) {
   }
 }
 
-export async function acknowledgeReleaseSuccess(
-  source: string,
-  xmlUrl: string,
-  messageId: string,
-  messageTimestamp: string,
+export async function acknowledgeReleaseSuccess({
+  source,
+  xmlUrl,
+  messageId,
+  messageTimestamp,
+  releases,
+}: {
+  source: string
+  xmlUrl: string
+  messageId: string
+  messageTimestamp: string
   releases: DDEXRelease[]
-) {
+}) {
   const result: AcknowledgementResult = {
     source,
     xmlUrl,
@@ -301,12 +311,12 @@ export async function acknowledgeReleaseSuccess(
   
   // Generate and log acknowledgement XML
   const acknowledgementXml = generateAcknowledgementXml(
-    source,
-    xmlUrl,
-    messageId,
-    messageTimestamp,
-    releases,
-    true
+    {
+      source,
+      messageId,
+      releases,
+      isSuccess: true
+    }
   )
   console.log(acknowledgementXml)
   
@@ -321,13 +331,19 @@ export async function acknowledgeReleaseSuccess(
   return result
 }
 
-export async function acknowledgeReleaseFailure(
-  source: string,
-  xmlUrl: string,
-  messageId: string,
-  messageTimestamp: string,
+export async function acknowledgeReleaseFailure({
+  source,
+  xmlUrl,
+  messageId,
+  messageTimestamp,
+  error,
+}: {
+  source: string
+  xmlUrl: string
+  messageId: string
+  messageTimestamp: string
   error: string | Error
-) {
+}) {
   const errorMessage = error instanceof Error ? error.message : error
   
   const result: AcknowledgementResult = {
@@ -347,13 +363,13 @@ export async function acknowledgeReleaseFailure(
   
   // Generate and log acknowledgement XML for failure
   const acknowledgementXml = generateAcknowledgementXml(
-    source,
-    xmlUrl,
-    messageId,
-    messageTimestamp,
-    [], // Empty releases array for failures
-    false,
-    errorMessage
+    {
+      source,
+      messageId,
+      releases: [], // Empty releases array for failures
+      isSuccess: false,
+      error: errorMessage
+    }
   )
   console.log(acknowledgementXml)
   

--- a/src/acknowledgement.ts
+++ b/src/acknowledgement.ts
@@ -1,0 +1,336 @@
+import * as cheerio from 'cheerio'
+import { DDEXRelease } from './parseDelivery'
+import { sources } from './sources'
+
+export type AcknowledgementResult = {
+  source: string
+  xmlUrl: string
+  messageTimestamp: string
+  success: boolean
+  error?: string
+  releaseCount?: number
+  releases?: DDEXRelease[]
+}
+
+// Bearer token cache with 1-hour expiration
+type TokenCacheEntry = {
+  token: string
+  expiresAt: number
+}
+
+const tokenCache: Map<string, TokenCacheEntry> = new Map()
+
+function getCachedToken(source: string): string | null {
+  const entry = tokenCache.get(source)
+  if (!entry) return null
+  
+  if (Date.now() > entry.expiresAt) {
+    // Token expired, remove from cache
+    tokenCache.delete(source)
+    return null
+  }
+  
+  return entry.token
+}
+
+function setCachedToken(source: string, token: string): void {
+  const expiresAt = Date.now() + (60 * 60 * 1000) // 1 hour from now
+  tokenCache.set(source, { token, expiresAt })
+}
+
+function getSourcePartyName(source: string): string {
+  switch (source) {
+    case 'sme':
+      return 'Sony Music Entertainment'
+    default:
+      return source
+  }
+}
+
+function generateAcknowledgementXml(
+  source: string,
+  xmlUrl: string,
+  messageId: string,
+  messageTimestamp: string,
+  releases: DDEXRelease[],
+  isSuccess: boolean,
+  error?: string
+): string {
+  const $ = cheerio.load('', { xmlMode: true })
+  
+  // Create root element
+  const root = $('<ns3:AcknowledgementMessage></ns3:AcknowledgementMessage>')
+  root.attr('xmlns:xs', 'http://www.w3.org/2001/XMLSchema-instance')
+  root.attr('xmlns:ns3', 'http://ddex.net/xml/ern-c-sftp/18')
+  root.attr('AvsVersionId', '4')
+  
+  // MessageHeader
+  const messageHeader = $('<MessageHeader></MessageHeader>')
+  messageHeader.append($(`<MessageId>${messageId}</MessageId>`))
+  
+  // MessageSender (Audius as the distributor)
+  const messageSender = $('<MessageSender></MessageSender>')
+  messageSender.append($('<PartyId>PADPIDA202401120D9</PartyId>'))
+  const senderPartyName = $('<PartyName></PartyName>')
+  senderPartyName.append($('<FullName>Tiki Labs, Inc.</FullName>'))
+  messageSender.append(senderPartyName)
+  messageHeader.append(messageSender)
+  
+  // MessageRecipient (Source)
+  const messageRecipient = $('<MessageRecipient></MessageRecipient>')
+  messageRecipient.append($(`<PartyId>${source.toUpperCase()}</PartyId>`))
+  const recipientPartyName = $('<PartyName></PartyName>')
+  recipientPartyName.append($(`<FullName>${getSourcePartyName(source)}</FullName>`))
+  messageRecipient.append(recipientPartyName)
+  messageHeader.append(messageRecipient)
+  
+  // MessageCreatedDateTime
+  const currentTime = new Date().toISOString()
+  messageHeader.append($(`<MessageCreatedDateTime>${currentTime}</MessageCreatedDateTime>`))
+  
+  root.append(messageHeader)
+  
+  // If we have releases, create ReleaseStatus entries for each
+  if (releases.length > 0) {
+    for (const release of releases) {
+      const releaseStatus = $('<ReleaseStatus></ReleaseStatus>')
+      
+      // ReleaseId - prefer GRid (especially for SME), fallback to other IDs
+      const releaseId = $('<ReleaseId></ReleaseId>')
+      if (release.releaseIds.grid) {
+        releaseId.append($(`<GRid>${release.releaseIds.grid}</GRid>`))
+      } else if (release.releaseIds.catalog_number) {
+        releaseId.append($(`<CatalogNumber>${release.releaseIds.catalog_number}</CatalogNumber>`))
+      } else if (release.releaseIds.icpn) {
+        releaseId.append($(`<ICPN>${release.releaseIds.icpn}</ICPN>`))
+      } else if (release.releaseIds.proprietary_id) {
+        releaseId.append($(`<ProprietaryId>${release.releaseIds.proprietary_id}</ProprietaryId>`))
+      } else {
+        // Use the ref as fallback
+        releaseId.append($(`<ProprietaryId>${release.ref}</ProprietaryId>`))
+      }
+      releaseStatus.append(releaseId)
+      
+      // ReleaseStatus - different values for success vs error
+      if (isSuccess) {
+        releaseStatus.append($('<ReleaseStatus>SuccessfullyIngestedByReleaseDistributor</ReleaseStatus>'))
+      } else {
+        releaseStatus.append($('<ReleaseStatus>ProcessingErrorAtReleaseDistributor</ReleaseStatus>'))
+        
+        // Add ErrorText for failures (at ReleaseStatus level)
+        if (error) {
+          releaseStatus.append($(`<ErrorText>${error}</ErrorText>`))
+        }
+      }
+      
+      // Acknowledgement
+      const acknowledgement = $('<Acknowledgement></Acknowledgement>')
+      acknowledgement.append($('<MessageType>NewReleaseMessage</MessageType>'))
+      acknowledgement.append($(`<MessageId>${messageId}</MessageId>`))
+      
+      const messageStatus = $('<MessageStatus></MessageStatus>')
+      if (isSuccess) {
+        messageStatus.append($('<Status>FileOK</Status>'))
+      } else {
+        // Use ResourceCorrupt for errors as per the example
+        messageStatus.append($('<Status>ResourceCorrupt</Status>'))
+      }
+      
+      acknowledgement.append(messageStatus)
+      releaseStatus.append(acknowledgement)
+      
+      root.append(releaseStatus)
+    }
+  } else {
+    // No releases - create a general acknowledgement
+    const generalAcknowledgement = $('<Acknowledgement></Acknowledgement>')
+    generalAcknowledgement.append($('<MessageType>NewReleaseMessage</MessageType>'))
+    generalAcknowledgement.append($(`<MessageId>${messageId}</MessageId>`))
+    
+    const messageStatus = $('<MessageStatus></MessageStatus>')
+    if (isSuccess) {
+      messageStatus.append($('<Status>FileOK</Status>'))
+    } else {
+      messageStatus.append($('<Status>ResourceCorrupt</Status>'))
+      
+      if (error) {
+        messageStatus.append($(`<StatusMessage>${error}</StatusMessage>`))
+      }
+    }
+    
+    generalAcknowledgement.append(messageStatus)
+    root.append(generalAcknowledgement)
+  }
+  
+  // Add XML declaration and return
+  const xmlDeclaration = '<?xml version="1.0"?>\n'
+  return xmlDeclaration + $.html(root)
+}
+
+async function sendAcknowledgement(source: string, xml: string) {
+  const sourceConfig = sources.findByName(source)
+  if (!sourceConfig) {
+    console.error('No source config found for', source)
+    return
+  }
+
+  const { acknowledgementServerUsername, acknowledgementServerPassword } = sourceConfig
+  
+  if (!acknowledgementServerUsername || !acknowledgementServerPassword) {
+    console.error('Missing acknowledgement server credentials for source', source)
+    return
+  }
+
+  const DPID = 'PADPIDA202401120D9'
+  
+  try {
+    // Step 1: Generate Gateway Bearer Token (only if not cached)
+    let bearerToken = getCachedToken(source)
+    if (!bearerToken) {
+      const tokenUrl = `https://delivery-gw.smecde.com/gateway/token/${DPID}`
+      const basicAuth = Buffer.from(`${acknowledgementServerUsername}:${acknowledgementServerPassword}`).toString('base64')
+
+      console.log('Requesting bearer token from:', tokenUrl)
+      const tokenResponse = await fetch(tokenUrl, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Basic ${basicAuth}`,
+          'Content-Type': 'application/json'
+        }
+      })
+
+      if (!tokenResponse.ok) {
+        throw new Error(`Token request failed: ${tokenResponse.status} ${tokenResponse.statusText}`)
+      }
+
+      bearerToken = await tokenResponse.text()
+      console.log('Bearer token obtained')
+      
+      // Cache the token for 1 hour
+      setCachedToken(source, bearerToken)
+    } else {
+      console.log('Using cached bearer token')
+    }
+
+    // Step 2: Post the XML using the bearer token
+    const statusUrl = `https://delivery-gw.smecde.com/gateway/ddex/ern/post/status/${DPID}`
+    console.log('Posting acknowledgement XML to:', statusUrl)
+    
+    // const statusResponse = await fetch(statusUrl, {
+    //   method: 'POST',
+    //   headers: {
+    //     'Authorization': `Bearer ${bearerToken}`,
+    //     'Content-Type': 'application/xml'
+    //   },
+    //   body: xml
+    // })
+    
+    // if (!statusResponse.ok) {
+    //   throw new Error(`Status post failed: ${statusResponse.status} ${statusResponse.statusText}`)
+    // }
+    
+    console.log('Acknowledgement XML posted successfully')
+  } catch (error) {
+    console.error('Failed to send acknowledgement:', error)
+    throw error
+  }
+}
+
+export async function acknowledgeReleaseSuccess(
+  source: string,
+  xmlUrl: string,
+  messageId: string,
+  messageTimestamp: string,
+  releases: DDEXRelease[]
+) {
+  const result: AcknowledgementResult = {
+    source,
+    xmlUrl,
+    messageTimestamp,
+    success: true,
+    releaseCount: releases.length,
+    releases
+  }
+  
+  console.log('\nPreparing to send success acknowledgement:', {
+    source,
+    xmlUrl,
+    messageTimestamp,
+    releaseCount: releases.length,
+    releases: releases.map(r => ({
+      ref: r.ref,
+      title: r.title,
+      artists: r.artists.map(a => a.name),
+      problems: r.problems,
+      dealCount: r.deals.length
+    }))
+  })
+  
+  // Generate and log acknowledgement XML
+  const acknowledgementXml = generateAcknowledgementXml(
+    source,
+    xmlUrl,
+    messageId,
+    messageTimestamp,
+    releases,
+    true
+  )
+  console.log(acknowledgementXml)
+  
+  // Send acknowledgement message to source
+  try {
+    await sendAcknowledgement(source, acknowledgementXml)
+  } catch (error) {
+    console.error('Failed to send success acknowledgement:', error)
+    // Don't throw - acknowledgement failure shouldn't stop the main flow
+  }
+  
+  return result
+}
+
+export async function acknowledgeReleaseFailure(
+  source: string,
+  xmlUrl: string,
+  messageId: string,
+  messageTimestamp: string,
+  error: string | Error
+) {
+  const errorMessage = error instanceof Error ? error.message : error
+  
+  const result: AcknowledgementResult = {
+    source,
+    xmlUrl,
+    messageTimestamp,
+    success: false,
+    error: errorMessage
+  }
+  
+  console.log('\nPreparing to send failure acknowledgement:', {
+    source,
+    xmlUrl,
+    messageTimestamp,
+    error: errorMessage
+  })
+  
+  // Generate and log acknowledgement XML for failure
+  const acknowledgementXml = generateAcknowledgementXml(
+    source,
+    xmlUrl,
+    messageId,
+    messageTimestamp,
+    [], // Empty releases array for failures
+    false,
+    errorMessage
+  )
+  console.log(acknowledgementXml)
+  
+  // Send acknowledgement message to source
+  try {
+    await sendAcknowledgement(source, acknowledgementXml)
+  } catch (error) {
+    console.error('Failed to send failure acknowledgement:', error)
+    // Don't throw - acknowledgement failure shouldn't stop the main flow
+  }
+  
+  return result
+} 

--- a/src/parseDelivery.ts
+++ b/src/parseDelivery.ts
@@ -233,7 +233,13 @@ export async function parseDdexXml(
         // Only send acknowledgement for SME
         source === 'sme'
       ) {
-        await acknowledgeReleaseSuccess(source, xmlUrl, messageId, messageTimestamp, releases)
+        await acknowledgeReleaseSuccess({
+          source,
+          xmlUrl,
+          messageId,
+          messageTimestamp,
+          releases,
+        })
       }
       
       return releases
@@ -260,7 +266,13 @@ export async function parseDdexXml(
       // Only send acknowledgement for SME
       source === 'sme'
     ) {
-      await acknowledgeReleaseFailure(source, xmlUrl, messageId, messageTimestamp, error as Error)
+      await acknowledgeReleaseFailure({
+        source,
+        xmlUrl,
+        messageId,
+        messageTimestamp,
+        error: error as Error
+      })
     }
     
     // Re-throw the error so it can be handled by the caller

--- a/src/parseDelivery.ts
+++ b/src/parseDelivery.ts
@@ -5,6 +5,7 @@ import type { Element } from 'domhandler'
 import { mkdtemp, readFile, readdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { acknowledgeReleaseFailure, acknowledgeReleaseSuccess } from './acknowledgement'
 import { releaseRepo, userRepo, xmlRepo } from './db'
 import { sources } from './sources'
 import { lowerAscii, omitEmpty } from './util'
@@ -186,47 +187,84 @@ export async function parseDdexXml(
   xmlUrl: string,
   xmlText: string
 ) {
-  const $ = cheerio.load(xmlText, { xmlMode: true })
+  try {
+    const $ = cheerio.load(xmlText, { xmlMode: true })
 
-  const messageTimestamp = $('MessageCreatedDateTime').first().text()
-  const rawTagName = $.root().children().first().prop('name')
-  const tagName = [
-    'NewReleaseMessage',
-    'PurgeReleaseMessage',
-    'ManifestMessage',
-  ].find((n) => rawTagName.includes(n))
-  const isUpdate = $('UpdateIndicator').text() == 'UpdateMessage'
+    const messageTimestamp = $('MessageCreatedDateTime').first().text()
+    const rawTagName = $.root().children().first().prop('name')
+    const tagName = [
+      'NewReleaseMessage',
+      'PurgeReleaseMessage',
+      'ManifestMessage',
+    ].find((n) => rawTagName.includes(n))
+    const isUpdate = $('UpdateIndicator').text() == 'UpdateMessage'
+    const messageId = $('MessageId').text()
 
-  // Detect DDEX version
-  const isDdex40 = xmlText.includes('http://ddex.net/xml/ern/4')
+    // Detect DDEX version
+    const isDdex40 = xmlText.includes('http://ddex.net/xml/ern/4')
 
-  // todo: would be nice to skip this on reParse
-  await xmlRepo.upsert({
-    source,
-    xmlUrl,
-    messageTimestamp,
-  })
-
-  if (tagName == 'ManifestMessage') {
-    // don't care about batch.
-  } else if (tagName == 'PurgeReleaseMessage') {
-    // mark release rows as DeletePending
-    const { releaseIds } = parsePurgeXml($)
-    await releaseRepo.markForDelete(
+    // todo: would be nice to skip this on reParse
+    await xmlRepo.upsert({
       source,
       xmlUrl,
       messageTimestamp,
-      releaseIds
-    )
-  } else if (tagName == 'NewReleaseMessage') {
-    // create or replace this release in db
-    const releases = await parseReleaseXml(source, $, isDdex40)
-    for (const release of releases) {
-      await releaseRepo.upsert(source, xmlUrl, messageTimestamp, release)
+    })
+
+    if (tagName == 'ManifestMessage') {
+      // don't care about batch.
+    } else if (tagName == 'PurgeReleaseMessage') {
+      // mark release rows as DeletePending
+      const { releaseIds } = parsePurgeXml($)
+      await releaseRepo.markForDelete(
+        source,
+        xmlUrl,
+        messageTimestamp,
+        releaseIds
+      )
+    } else if (tagName == 'NewReleaseMessage') {
+      // create or replace this release in db
+      const releases = await parseReleaseXml(source, $, isDdex40)
+      for (const release of releases) {
+        await releaseRepo.upsert(source, xmlUrl, messageTimestamp, release)
+      }
+      
+      if (
+        process.env.SEND_ACKNOWLEDGEMENTS === 'true' &&
+        // Only send acknowledgement for SME
+        source === 'sme'
+      ) {
+        await acknowledgeReleaseSuccess(source, xmlUrl, messageId, messageTimestamp, releases)
+      }
+      
+      return releases
+    } else {
+      console.log('unknown tagname', tagName)
     }
-    return releases
-  } else {
-    console.log('unknown tagname', tagName)
+  } catch (error) {
+    console.error('Failed to parse DDEX XML:', xmlUrl, error)
+    
+    // Extract messageTimestamp if possible, otherwise use current time
+    let messageTimestamp: string
+    let messageId: string
+    try {
+      const $ = cheerio.load(xmlText, { xmlMode: true })
+      messageTimestamp = $('MessageCreatedDateTime').first().text() || new Date().toISOString()
+      messageId = $('MessageId').text()
+    } catch {
+      messageTimestamp = new Date().toISOString()
+      messageId = ''
+    }
+    
+    if (
+      process.env.SEND_ACKNOWLEDGEMENTS === 'true' &&
+      // Only send acknowledgement for SME
+      source === 'sme'
+    ) {
+      await acknowledgeReleaseFailure(source, xmlUrl, messageId, messageTimestamp, error as Error)
+    }
+    
+    // Re-throw the error so it can be handled by the caller
+    throw error
   }
 }
 

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -29,6 +29,8 @@ export type SourceConfig = BucketConfig & {
   placementHosts?: string
   payoutUserId?: string
   labelUserIds: Record<string, string>
+  acknowledgementServerUsername?: string
+  acknowledgementServerPassword?: string
 }
 
 let sourcesFile: SourcesFile


### PR DESCRIPTION
Add AcknowledgementMessage support to ddex-processor.

Currently only works for source=sme

Instructions:

Follow existing README_DEV.md instructions. Then --

1. Modify .env
```
SEND_ACKNOWLEDGEMENTS='true'
```

2. Run worker (dry run until step 3)
```
npm run worker
```

3. Set credentials on sources.json. THIS WILL ACTUALLY SEND LIVE ACK MESSAGES!
Modify data/sources.json and add
```
acknowledgementServerUsername?: string
acknowledgementServerPassword?: string
```

& rerun worker
```
npm run worker
```