### PR TITLE
Fix misc ddex4.0 and sme processing bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@audius/sdk": "^9.0.0",
         "@aws-sdk/client-s3": "3.658.1",
         "@aws-sdk/credential-provider-ini": "3.658.1",
+        "@aws-sdk/s3-request-presigner": "^3.658.1",
         "@hono/node-server": "^1.13.1",
         "cheerio": "^1.0.0",
         "commander": "^12.1.0",
@@ -1078,6 +1079,24 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.658.1.tgz",
+      "integrity": "sha512-FQsECwePc34AAZU2mt0GUOppUIwOCLdsBkDQdCDyLDuWMN1+caYVzSAu++pJpkA+1MDdAKp4AiJyNiWbe/uI5g==",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.658.1",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-format-url": "3.654.0",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.658.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.658.1.tgz",
@@ -1143,6 +1162,20 @@
         "@aws-sdk/types": "3.654.0",
         "@smithy/types": "^3.4.2",
         "@smithy/util-endpoints": "^2.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.654.0.tgz",
+      "integrity": "sha512-2yAlJ/l1uTJhS52iu4+/EvdIyQhDBL+nATY8rEjFI0H+BHGVrJIH2CL4DByhvi2yvYwsqQX0HYah6pF/yoXukA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@audius/sdk": "^9.0.0",
     "@aws-sdk/client-s3": "3.658.1",
     "@aws-sdk/credential-provider-ini": "3.658.1",
+    "@aws-sdk/s3-request-presigner": "^3.658.1",
     "@hono/node-server": "^1.13.1",
     "cheerio": "^1.0.0",
     "commander": "^12.1.0",

--- a/src/parseDelivery.ts
+++ b/src/parseDelivery.ts
@@ -233,13 +233,26 @@ export async function parseDdexXml(
         // Only send acknowledgement for SME
         source === 'sme'
       ) {
-        await acknowledgeReleaseSuccess({
-          source,
-          xmlUrl,
-          messageId,
-          messageTimestamp,
-          releases,
-        })
+        const hasErrors = releases.some((r) =>
+          r.problems.includes('InvalidDealDate')
+        )
+        if (hasErrors) {
+          await acknowledgeReleaseFailure({
+            source,
+            xmlUrl,
+            messageId,
+            messageTimestamp,
+            error: 'InvalidDealDate',
+          })
+        } else {
+          await acknowledgeReleaseSuccess({
+            source,
+            xmlUrl,
+            messageId,
+            messageTimestamp,
+            releases,
+          })
+        }
       }
       
       return releases
@@ -401,7 +414,7 @@ async function parseReleaseXml(source: string, $: cheerio.CheerioAPI, isDdex40: 
     // DDEX 4.0 structure: DealList > ReleaseDeal > Deal > DealTerms
     $('DealList > ReleaseDeal').each((_, el) => {
       const $el = $(el)
-      const ref = $el.find('ReleaseReference').text()
+      const refs = $el.find('DealReleaseReference').toArray().map(el => $(el).text());
       
       $el.find('Deal > DealTerms').each((_, el) => {
         const $el = $(el)
@@ -434,8 +447,10 @@ async function parseReleaseXml(source: string, $: cheerio.CheerioAPI, isDdex40: 
 
         // add deal
         function addDeal(deal: AudiusSupportedDeal) {
-          releaseDeals[ref] ||= []
-          releaseDeals[ref].push(deal)
+          for (const ref of refs) {
+            releaseDeals[ref] ||= []
+            releaseDeals[ref].push(deal)
+          }
         }
 
         const common: DealFields = {
@@ -770,7 +785,38 @@ async function parseReleaseXml(source: string, $: cheerio.CheerioAPI, isDdex40: 
       const $el = $(el)
 
       const ref = $el.find('ReleaseReference').text()
-      const deals = releaseDeals[ref] || []
+      let deals = releaseDeals[ref] || []
+
+      // For DDEX 4.0, if the album has no direct deals, aggregate from TrackReleases
+      if (deals.length === 0 && isDdex40) {
+        // Build TrackRelease -> Resource mapping
+        const trackRefToResourceRef: Record<string, string> = {}
+        $('ReleaseList > TrackRelease').each((_, el) => {
+          const $tr = $(el)
+          const trRef = $tr.find('ReleaseReference').text()
+          const rrRef = $tr.find('ReleaseResourceReference').text()
+          if (trRef && rrRef) trackRefToResourceRef[trRef] = rrRef
+        })
+
+        // Collect resource refs contained in this album
+        const releaseResourceRefs = new Set<string>()
+        $el
+          .find('ResourceGroup ReleaseResourceReference, ResourceGroupContentItem > ReleaseResourceReference')
+          .each((_, el) => {
+            releaseResourceRefs.add($(el).text())
+          })
+
+        // Find TrackReleases that are members of this album
+        const memberTrackRefs = Object.entries(trackRefToResourceRef)
+          .filter(([, resRef]) => releaseResourceRefs.has(resRef))
+          .map(([trRef]) => trRef)
+
+        const aggregated = memberTrackRefs.flatMap((r) => releaseDeals[r] || [])
+        if (aggregated.length) {
+          deals = aggregated
+        }
+      }
+
       const validityStartDate = deals.length
         ? deals[0].validityStartDate
         : undefined
@@ -812,7 +858,7 @@ async function parseReleaseXml(source: string, $: cheerio.CheerioAPI, isDdex40: 
         producerCopyrightLine: pline($el),
         parentalWarningType: toText($el.find('ParentalWarningType')),
 
-        isMainRelease: $el.attr('IsMainRelease') == 'true',
+        isMainRelease: isDdex40 ? true : $el.attr('IsMainRelease') == 'true',
 
         problems: [],
         soundRecordings: [],
@@ -861,6 +907,40 @@ async function parseReleaseXml(source: string, $: cheerio.CheerioAPI, isDdex40: 
       // deal or no deal?
       if (!release.deals.length) {
         release.problems.push('NoDeal')
+      }
+
+      // Validate FirstPublicationDate/recording releaseDate
+      {
+        const hasInvalidDate = release.soundRecordings.some((sr) => {
+          const dateText = sr.releaseDate || ''
+          const m = dateText.match(/(\d{4})/)
+          if (!m) return true
+          const year = parseInt(m[1])
+          if (!year || year <= 1900) return true
+          return false
+        })
+        if (hasInvalidDate) {
+          release.problems.push('InvalidFirstPublicationDate')
+        }
+      }
+
+      // Validate deal start vs OriginalReleaseDate
+      {
+        const originalReleaseDateText = $el.find('OriginalReleaseDate').text()
+        if (originalReleaseDateText) {
+          const ord = new Date(originalReleaseDateText)
+          if (!isNaN(ord.getTime())) {
+            const invalidDeal = release.deals.some((d) => {
+              if (!d.validityStartDate) return false
+              const ds = new Date(d.validityStartDate)
+              if (isNaN(ds.getTime())) return false
+              return ds < ord
+            })
+            if (invalidDeal) {
+              release.problems.push('InvalidDealDate')
+            }
+          }
+        }
       }
 
       return release

--- a/src/parseDelivery.ts
+++ b/src/parseDelivery.ts
@@ -242,6 +242,7 @@ export async function parseDdexXml(
             xmlUrl,
             messageId,
             messageTimestamp,
+            releases,
             error: 'InvalidDealDate',
           })
         } else {

--- a/src/parseDelivery.ts
+++ b/src/parseDelivery.ts
@@ -967,7 +967,7 @@ function resolveAudiusGenre(
 
   // maybe try some edit distance magic?
   // for now just log
-  console.warn(`failed to resolve genre: subgenre=${subgenre} genre=${genre}`)
+  console.warn(`no matching genre: subgenre=${subgenre} genre=${genre}`)
 }
 
 export function parseDuration(dur: string) {

--- a/src/s3poller.ts
+++ b/src/s3poller.ts
@@ -227,14 +227,11 @@ export async function readAssetWithCaching(
     const destinationPath = join(
       ...[cacheBaseDir, Bucket, imageSize, Key].filter(Boolean)
     )
-    console.log('destinationPath', destinationPath)
 
     // fetch if needed
     const exists = await fileExists(destinationPath)
     if (!exists) {
-      console.log('fetching', xmlUrl)
       const source = sources.findByXmlUrl(xmlUrl)
-      console.log('source', source)
       const s3 = dialS3(source)
       await mkdir(dirname(destinationPath), { recursive: true })
       const { Body } = await s3.send(new GetObjectCommand({ Bucket, Key }))

--- a/src/s3poller.ts
+++ b/src/s3poller.ts
@@ -4,6 +4,7 @@ import {
   S3Client,
   S3ClientConfig,
 } from '@aws-sdk/client-s3'
+import * as cheerio from 'cheerio'
 import { mkdir, readFile, stat, writeFile } from 'fs/promises'
 import { basename, dirname, join, resolve } from 'path'
 import sharp from 'sharp'
@@ -80,14 +81,32 @@ export async function pollS3Source(
 
     // Handle case where there are common prefixes (folder structure)
     if (prefixes && prefixes.length > 0) {
-      const batchSize = 20
+      const batchSize = 100
       for (let i = 0; i < prefixes.length; i += batchSize) {
         const batch = prefixes.slice(i, i + batchSize)
+        
+        // Collect all files from all prefixes in this batch
+        const allFiles: any[] = []
+        
+        // Fetch files from all prefixes in parallel for efficiency
         await Promise.all(
           batch.map(async (prefix) => {
-            await scanS3Prefix(sourceName, client, bucket, prefix)
+            const prefixResult = await client.send(
+              new ListObjectsCommand({
+                Bucket: bucket,
+                Prefix: prefix,
+              })
+            )
+            if (prefixResult.Contents) {
+              allFiles.push(...prefixResult.Contents)
+            }
           })
         )
+
+        // Process all files in chronological order
+        if (allFiles.length > 0) {
+          await processS3Contents(sourceName, client, bucket, allFiles)
+        }
       }
       
       // save marker for prefixes
@@ -126,26 +145,45 @@ async function processS3Contents(
   bucket: string,
   contents: any[]
 ) {
-  for (const c of contents) {
-    if (!c.Key) continue
-
-    const lowerKey = c.Key.toLowerCase()
-    if (!lowerKey.endsWith('.xml') || lowerKey.includes('batchcomplete')) {
-      continue
-    }
-
-    const xmlUrl = `s3://` + join(bucket, c.Key)
-    const { Body } = await client.send(
-      new GetObjectCommand({
-        Bucket: bucket,
-        Key: c.Key,
+  // First, fetch and parse all XML files to get their timestamps
+  const filesWithTimestamps = await Promise.all(
+    contents
+      .filter(c => c.Key?.toLowerCase().endsWith('.xml') && !c.Key.includes('batchcomplete'))
+      .map(async (c) => {
+        try {
+          const { Body } = await client.send(
+            new GetObjectCommand({
+              Bucket: bucket,
+              Key: c.Key,
+            })
+          )
+          const xml = await Body?.transformToString()
+          if (xml) {
+            const $ = cheerio.load(xml, { xmlMode: true })
+            const messageTimestamp = $('MessageCreatedDateTime').first().text()
+            return { key: c.Key, xml, messageTimestamp }
+          }
+        } catch (error) {
+          console.error(`Failed to fetch/parse ${c.Key}:`, error)
+        }
+        return null
       })
-    )
-    const xml = await Body?.transformToString()
-    if (xml) {
-      console.log('parsing', xmlUrl)
-      const releases = (await parseDdexXml(source, xmlUrl, xml)) || []
-    }
+  )
+
+  // Sort by messageTimestamp, handling cases where timestamp might be missing
+  const sortedFiles = filesWithTimestamps
+    .filter(Boolean)
+    .sort((a, b) => {
+      const timestampA = a!.messageTimestamp || ''
+      const timestampB = b!.messageTimestamp || ''
+      return timestampA.localeCompare(timestampB)
+    })
+
+  // Process in chronological order
+  for (const file of sortedFiles) {
+    const xmlUrl = `s3://` + join(bucket, file!.key)
+    console.log('parsing', xmlUrl, 'timestamp:', file!.messageTimestamp)
+    const releases = (await parseDdexXml(source, xmlUrl, file!.xml)) || []
   }
 }
 

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -341,6 +341,7 @@ app.get('/releases', async (c) => {
             <th>Genre</th>
             <th>Release</th>
             <th>Clear</th>
+            <th>Status</th>
             <th></th>
             <th></th>
             <th>debug</th>
@@ -405,6 +406,7 @@ ${row.soundRecordings.length} tracks`}
                   </div>
                 )}
               </td>
+              <td>{row.status}</td>
               <td>
                 {row.publishErrorCount > 0 && (
                   <a href={`/releases/${encodeURIComponent(row.key)}/error`}>

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -406,7 +406,28 @@ ${row.soundRecordings.length} tracks`}
                   </div>
                 )}
               </td>
-              <td>{row.status}</td>
+              <td>
+                {row.status}
+                {row.problems?.length > 0 && (
+                  <div style={{ marginTop: '4px', display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+                    {row.problems.map((p) => (
+                      <span
+                        style={{
+                          display: 'inline-block',
+                          border: '1px solid var(--pico-muted-border-color, #ccc)',
+                          borderRadius: '4px',
+                          padding: '1px 4px',
+                          fontSize: '11px',
+                          lineHeight: 1.4,
+                        }}
+                        title={p}
+                      >
+                        {p}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </td>
               <td>
                 {row.publishErrorCount > 0 && (
                   <a href={`/releases/${encodeURIComponent(row.key)}/error`}>

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -784,7 +784,6 @@ app.get('/release/:source/:key/:ref/:size?', async (c) => {
   const size = c.req.param('size')
 
   const asset = await assetRepo.get(source, key, ref)
-  console.log('asset', asset)
   if (!asset) return c.json({ error: 'not found' }, 404)
 
   // If no resizing requested (a stream instead of an image),


### PR DESCRIPTION
This was painful!
- Fix S3 polling so that we do things in order and never process an update/delete before the original message (increase batch size and sort files in chronological order)
- Add presigned s3 urls to load UI faster for debugging (instead of proxying files through local disk)
- Fix acknowledgement message formatting, particularly make sure to include release info in failure message
- Fix deal parsing for ddex 4.0 Release / TrackRelease fields
- Add "problems" for InvalidFirstPublicationDate and InvalidDealDate
- Add "problems" to the UI for better debugging



Tested via prod s3 dump.
```
npm run worker
```
using the correct source config

Manually reviewed recent dump