### PR TITLE
Map Country-Rock genre to Country

### DIFF
--- a/src/genreMapping.ts
+++ b/src/genreMapping.ts
@@ -104,6 +104,7 @@ export const genreMapping: Record<string, Genre> = {
 
   // Country
   Country: Genre.COUNTRY,
+  'Country-Rock': Genre.COUNTRY,
 
   // Folk
   Folk: Genre.FOLK,


### PR DESCRIPTION
## Summary
- Add `Country-Rock` → `Genre.COUNTRY` to the genre mapping so DDEX deliveries with that genre string resolve instead of failing to publish.

## Test plan
- [ ] Parse a release with `<Genre>Country-Rock</Genre>` and confirm `audiusGenre` resolves to `Country`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)