### PR TITLE
Detect claimed handles before signUp, allow handle override

### DIFF
--- a/src/claimable/createUserPublish.ts
+++ b/src/claimable/createUserPublish.ts
@@ -28,7 +28,11 @@ export async function publishToClaimableAccount(releaseId: string) {
   }
 
   const artistName = release.artists[0].name
-  const handle = artistName.replace(/[^a-zA-Z0-9.]/g, '')
+  // releaseRow.audiusHandle is an admin override set in the UI when the
+  // default-derived handle collides with an existing audius user. When set,
+  // we trust it and bypass the per-row regex stripping.
+  const handle =
+    releaseRow.audiusHandle || artistName.replace(/[^a-zA-Z0-9.]/g, '')
 
   // read image asset file
   async function resolveFile({ ref }: DDEXResource) {
@@ -43,105 +47,135 @@ export async function publishToClaimableAccount(releaseId: string) {
   const email = `ddex-support+${handle}@audius.co`
   const password = randomBytes(16).toString('hex')
 
-  try {
-    // attempt to find existing user record
-    // if not found, create a claimable account
-    let encodedUserId = await userRepo.match(source.ddexKey, [artistName])
-    if (!encodedUserId) {
-      // no user: create claimable user
-      console.log(`=== creating claimable account for ${artistName}`)
-      const hedgehog = getHedgehog()
-      const identityResult = await hedgehog.signUp({
-        username: email,
-        password,
-      })
-      console.log('identityResult', identityResult)
+  // attempt to find existing user record
+  // if not found, create a claimable account
+  let encodedUserId = await userRepo.match(source.ddexKey, [artistName])
+  if (!encodedUserId) {
+    // Refuse to signUp if the handle is already claimed on Audius — that
+    // produces an orphaned identity row with no audius user (createUser fails
+    // downstream because the handle is taken). Admin can set audiusHandle in
+    // the UI to publish under a different handle.
+    await assertHandleAvailable(handle, source.env || 'staging')
 
-      const { login } = await generateRecoveryInfo()
-      const lookupKey = await WalletManager.createAuthLookupKey(
-        email,
-        password,
-        hedgehog.createKey
-      )
+    // no user: create claimable user
+    console.log(`=== creating claimable account for ${artistName}`)
+    const hedgehog = getHedgehog()
+    const identityResult = await hedgehog.signUp({
+      username: email,
+      password,
+    })
+    console.log('identityResult', identityResult)
 
-      const audiusWalletClient = createHedgehogWalletClient(getHedgehog())
-      const userSdk = sdk({
-        appName: 'ddex',
-        environment: source.env || 'staging',
-        services: {
-          audiusWalletClient,
-        },
-      })
-
-      const newUser = await userSdk.users.createUser({
-        metadata: {
-          handle: handle,
-          name: artistName,
-          wallet: identityResult.getAddressString(),
-        },
-      })
-
-      await publogRepo.log({
-        release_id: release.key,
-        msg: 'created user',
-        extra: newUser,
-      })
-
-      // const entropy = localStorage.getItem('hedgehog-entropy-key')
-      encodedUserId = encodeId(newUser.metadata.userId)
-      console.log(newUser, encodedUserId)
-
-      // upload profile picture + cover photo
-      const updateImageResult = await userSdk.users.updateProfile({
-        userId: encodedUserId,
-        metadata: {},
-        profilePictureFile: imageFile as any,
-        coverArtFile: imageFile as any,
-      })
-      console.log('updateImageResult', updateImageResult)
-
-      await publogRepo.log({
-        release_id: release.key,
-        msg: 'set user image',
-        extra: updateImageResult,
-      })
-
-      // authorize source ddex app
-      const grantResult = await userSdk.grants.createGrant({
-        userId: encodedUserId,
-        appApiKey: source.ddexKey,
-      })
-      console.log('grantResult', grantResult)
-
-      await publogRepo.log({
-        release_id: release.key,
-        msg: 'user grant',
-        extra: grantResult,
-      })
-
-      // save user details to db
-      await userRepo.upsert({
-        id: encodedUserId,
-        apiKey: source.ddexKey,
-        handle: handle,
-        name: artistName,
-        login,
-        lookupKey,
-        createdAt: new Date(),
-      })
-    }
-
-    // save release with associated audius user
-    release.audiusUser = encodedUserId
-    await releaseRepo.upsert(
-      releaseRow.source,
-      releaseRow.xmlUrl,
-      releaseRow.messageTimestamp,
-      release
+    const { login } = await generateRecoveryInfo()
+    const lookupKey = await WalletManager.createAuthLookupKey(
+      email,
+      password,
+      hedgehog.createKey
     )
 
-    await publishRelease(source!, releaseRow, release)
-  } catch (e) {
-    console.log('publish error', e)
+    const audiusWalletClient = createHedgehogWalletClient(getHedgehog())
+    const userSdk = sdk({
+      appName: 'ddex',
+      environment: source.env || 'staging',
+      services: {
+        audiusWalletClient,
+      },
+    })
+
+    const newUser = await userSdk.users.createUser({
+      metadata: {
+        handle: handle,
+        name: artistName,
+        wallet: identityResult.getAddressString(),
+      },
+    })
+
+    await publogRepo.log({
+      release_id: release.key,
+      msg: 'created user',
+      extra: newUser,
+    })
+
+    encodedUserId = encodeId(newUser.metadata.userId)
+    console.log(newUser, encodedUserId)
+
+    // upload profile picture + cover photo
+    const updateImageResult = await userSdk.users.updateProfile({
+      userId: encodedUserId,
+      metadata: {},
+      profilePictureFile: imageFile as any,
+      coverArtFile: imageFile as any,
+    })
+    console.log('updateImageResult', updateImageResult)
+
+    await publogRepo.log({
+      release_id: release.key,
+      msg: 'set user image',
+      extra: updateImageResult,
+    })
+
+    // authorize source ddex app
+    const grantResult = await userSdk.grants.createGrant({
+      userId: encodedUserId,
+      appApiKey: source.ddexKey,
+    })
+    console.log('grantResult', grantResult)
+
+    await publogRepo.log({
+      release_id: release.key,
+      msg: 'user grant',
+      extra: grantResult,
+    })
+
+    // save user details to db
+    await userRepo.upsert({
+      id: encodedUserId,
+      apiKey: source.ddexKey,
+      handle: handle,
+      name: artistName,
+      login,
+      lookupKey,
+      createdAt: new Date(),
+    })
   }
+
+  // save release with associated audius user
+  release.audiusUser = encodedUserId
+  await releaseRepo.upsert(
+    releaseRow.source,
+    releaseRow.xmlUrl,
+    releaseRow.messageTimestamp,
+    release
+  )
+
+  await publishRelease(source!, releaseRow, release)
+}
+
+/**
+ * Throws HandleClaimed if a discovery user already exists with this handle.
+ * Caller's error gets surfaced as the release's lastPublishError, prompting
+ * the admin to set an audiusHandle override in the UI.
+ */
+async function assertHandleAvailable(handle: string, env: string) {
+  const apiHost =
+    env === 'production'
+      ? 'https://api.audius.co'
+      : 'https://api.staging.audius.co'
+  const res = await fetch(
+    `${apiHost}/v1/users/handle/${encodeURIComponent(handle)}`
+  )
+  if (res.status === 404) return
+  if (!res.ok) {
+    throw new Error(
+      `discovery handle check failed for ${handle}: HTTP ${res.status}`
+    )
+  }
+  const profileUrl =
+    env === 'production'
+      ? `https://audius.co/${handle}`
+      : `https://staging.audius.co/${handle}`
+  throw new Error(
+    `HandleClaimed: '${handle}' already exists on Audius (${profileUrl}). ` +
+      `Set audiusHandle in the UI to publish under a different handle.`
+  )
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -45,6 +45,7 @@ export type ReleaseRow = DDEXRelease & {
   numNotCleared: number
   prependArtist: string
   useDefaultDeal: boolean
+  audiusHandle?: string
   entityType?: 'track' | 'album'
   entityId?: string
   blockHash?: string

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -149,6 +149,8 @@ const steps = [
   sql`ALTER TABLE users ADD COLUMN IF NOT EXISTS "login" text;`,
   sql`ALTER TABLE users ADD COLUMN IF NOT EXISTS "lookupKey" text;`,
   sql`ALTER TABLE "s3markers" ADD COLUMN IF NOT EXISTS "last_modified" timestamptz;`,
+
+  sql`ALTER TABLE releases ADD COLUMN IF NOT EXISTS "audiusHandle" text;`,
 ]
 
 // poor man's migrate

--- a/src/db/releaseRepo.ts
+++ b/src/db/releaseRepo.ts
@@ -185,6 +185,14 @@ export const releaseRepo = {
     `
   },
 
+  async markAudiusHandle(key: string, audiusHandle: string | null) {
+    await sql`
+      update releases set
+      "audiusHandle"=${audiusHandle}
+      where key = ${key}
+    `
+  },
+
   async markForDelete(
     source: string,
     xmlUrl: string,

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -795,6 +795,25 @@ app.get('/releases/:key', async (c) => {
                       ))}
                   </select>
                 </fieldset>
+
+                <fieldset>
+                  <label title="Override the handle used for the auto-created Audius account. Only used when no Audius User is selected above. Leave blank to derive from artist name.">
+                    Audius Handle Override
+                  </label>
+                  <input
+                    type="text"
+                    name="audiusHandle"
+                    value={row.audiusHandle || ''}
+                    placeholder={parsedRelease.artists[0]?.name?.replace(
+                      /[^a-zA-Z0-9.]/g,
+                      ''
+                    )}
+                  />
+                  <small>
+                    If the default handle is already taken on Audius, set a
+                    unique one here. Allowed chars: letters, digits, dots.
+                  </small>
+                </fieldset>
               </div>
 
               <footer>
@@ -1618,6 +1637,11 @@ app.post('/publish/:releaseId', async (c) => {
     await releaseRepo.markUseDefaultDeal(releaseId, true)
   }
 
+  if (typeof body.audiusHandle === 'string') {
+    const trimmed = body.audiusHandle.trim()
+    await releaseRepo.markAudiusHandle(releaseId, trimmed || null)
+  }
+
   if (body.userId) {
     const userId = body.userId as string
     if (!source.ddexKey) {
@@ -1649,7 +1673,10 @@ app.post('/publish/:releaseId', async (c) => {
   // can exceed 60s request timeout, so fire and forget
   // TODO: this will always publish new release
   // need to add conditional update logic
-  publishToClaimableAccount(releaseId)
+  publishToClaimableAccount(releaseId).catch(async (e) => {
+    console.log('publish error', releaseId, e)
+    await releaseRepo.addPublishError(releaseId, e)
+  })
 
   return c.redirect(`/releases/${releaseId}/publog?poll=1`)
 })


### PR DESCRIPTION
## Summary

- Pre-flight `assertHandleAvailable()` check against `/v1/users/handle/<h>` before `signUp` in `publishToClaimableAccount`. If the handle is taken on Audius, throws `HandleClaimed: ...` with the profile URL so admins can see what's wrong in the UI instead of silently looping.
- New `audiusHandle` column on `releases` acts as an admin override of the regex-derived handle. Surfaced as a text input in the Publish modal. When set, autoPublish uses it (after re-checking discovery) so admins can resolve a `HandleClaimed` conflict by typing a free handle and re-pressing Publish.
- Remove the inner `catch (e) { console.log('publish error', e) }` that was swallowing every failure from the create-account flow. Errors now propagate to `addPublishError`, both from the worker (`publishValidPendingReleases`) and the UI route (`/publish/:releaseId`).

## Why

For ~10 production artists (Lefa22, Soundseeker, Pedroni, Nivel, John Korbel, J.H.Kulberg, Slyide, steve bass, Tony-O, and others) the autoPublish flow was creating a new identity row with a fresh wallet, then failing on `createUser` because the handle was already taken on the network — leaving an orphaned identity row, no Audius user, and no local `users` row. Every worker tick repeated the same failed signUp and produced the same `set user failed {"error":"Account already exists for user, try logging in"}` log. The failure was never surfaced on the release itself because the catch swallowed it.

## Behavior on the next tick after deploy

For each of those ~10 releases:
1. Worker calls `publishToClaimableAccount` → `userRepo.match` still returns null (their local rows were never written).
2. `assertHandleAvailable` GETs the discovery handle → 200 → throws `HandleClaimed: 'lefa22' already exists on Audius (https://audius.co/lefa22). Set audiusHandle in the UI to publish under a different handle.`
3. Outer handler calls `addPublishError` → status=`Failed`, message visible in the release UI.
4. Admin opens the release, sees the message, opens the Publish modal, types a unique handle into the new "Audius Handle Override" field, submits.
5. `/publish` saves `audiusHandle`, fire-and-forgets `publishToClaimableAccount`; this time the discovery check passes (the override is free) and the new account is created + published normally.

## Test plan

- [ ] Deploy and watch worker logs — confirm the failing ~10 releases now produce a single `HandleClaimed` error on the next tick (not the looping `set user failed` we've been seeing all week)
- [ ] Open one of them (e.g. release for Soundseeker) in the UI and confirm the `HandleClaimed` error renders in the existing error card
- [ ] Type a unique handle (e.g. `soundseeker.onchain`) into the Audius Handle Override field, press Publish, confirm the new account is created and release publishes
- [ ] Confirm an artist with a free handle (e.g. a brand-new release that comes in via S3 poll) still goes through the normal happy path
- [ ] Confirm the existing `users` row path (KyssKyss, lisyg) still publishes on next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)