### PR TITLE
Mirror-based image fallback so artwork always loads

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -297,6 +297,11 @@ app.get('/releases', async (c) => {
 
   const showPagination = offset || rows.length == limit
 
+  // For Published rows, fetch Audius artwork (with mirror hosts) up front so
+  // each <img> can be rendered with the full primary+mirrors URL list and
+  // the client-side MirrorImage script can advance on slow/dead nodes.
+  const mirrorUrlsByKey = await batchMirrorUrls(rows, '480x480')
+
   function withQueryParam(k: string, v: any) {
     const u = requestUrl(c)
     u.searchParams.set(k, v)
@@ -422,11 +427,22 @@ app.get('/releases', async (c) => {
             <tr>
               <td style="min-width: 80px; width: 120px;">
                 {row.images?.[0]?.ref ? (
-                  <img
-                    src={`/release/${row.source}/${row.key}/${row.images[0].ref}/200`}
-                    width="80"
-                    height="80"
-                  />
+                  mirrorUrlsByKey.get(row.key)?.length ? (
+                    <img
+                      data-mirror-urls={JSON.stringify(
+                        mirrorUrlsByKey.get(row.key)
+                      )}
+                      width="80"
+                      height="80"
+                      alt=""
+                    />
+                  ) : (
+                    <img
+                      src={`/release/${row.source}/${row.key}/${row.images[0].ref}/200`}
+                      width="80"
+                      height="80"
+                    />
+                  )
                 ) : (
                   <div
                     style={{
@@ -595,6 +611,12 @@ app.get('/releases/:key', async (c) => {
     ? publishableUsers.find((u) => u.id == parsedRelease.audiusUser)
     : undefined
 
+  // For Published releases, pull the Audius artwork with mirror hosts so the
+  // detail page <img> can fall back through mirrors when a node is unresponsive.
+  const detailMirrorUrls = row.entityId
+    ? buildMirrorUrls(await getAudiusArtwork(row), '480x480')
+    : []
+
   const mapArtist = (section: string) => (c: DDEXContributor) =>
     html`<tr>
       <td>${searchLink(c.name)}</td>
@@ -618,15 +640,28 @@ app.get('/releases/:key', async (c) => {
 
         <div style={{ display: 'flex', gap: '20px' }}>
           <div>
-            <img
-              src={`/release/${row.source}/${row.key}/${parsedRelease.images[0]?.ref}/200`}
-              style={{
-                width: '200px',
-                height: '200px',
-                display: 'block',
-                marginBottom: '10px',
-              }}
-            />
+            {detailMirrorUrls.length ? (
+              <img
+                data-mirror-urls={JSON.stringify(detailMirrorUrls)}
+                alt=""
+                style={{
+                  width: '200px',
+                  height: '200px',
+                  display: 'block',
+                  marginBottom: '10px',
+                }}
+              />
+            ) : (
+              <img
+                src={`/release/${row.source}/${row.key}/${parsedRelease.images[0]?.ref}/200`}
+                style={{
+                  width: '200px',
+                  height: '200px',
+                  display: 'block',
+                  marginBottom: '10px',
+                }}
+              />
+            )}
 
             <table style={{ width: '100%', fontSize: '90%' }} class="compact">
               {infoRowLink('Source', row.source)}
@@ -1358,6 +1393,79 @@ function pickAudiusArtworkUrl(artwork: any, size?: string): string | undefined {
     }
   }
   return best
+}
+
+// Audius artwork comes back as `{ '150x150': url, '480x480': url, '1000x1000':
+// url, mirrors: [host, host, ...] }`. The browser will stall indefinitely on
+// a slow/dead content node because `onerror` only fires on hard failures, so
+// we build a full primary-then-mirrors URL list that the client can try in
+// sequence with a per-URL timeout.
+function buildMirrorUrls(artwork: any, size: string = '480x480'): string[] {
+  if (!artwork) return []
+  const primary = artwork[size] || artwork['480x480'] || artwork['150x150']
+  if (!primary) return []
+  const mirrors: string[] = Array.isArray(artwork.mirrors) ? artwork.mirrors : []
+  if (!mirrors.length) return [primary]
+  let path: string
+  try {
+    path = new URL(primary).pathname
+  } catch {
+    return [primary]
+  }
+  return [primary, ...mirrors.map((root: string) => root.replace(/\/$/, '') + path)]
+}
+
+// In-memory cache for Audius artwork objects so a page render doesn't issue
+// one API call per row on every refresh. CIDs are stable, so a long TTL is
+// safe; we still poke through after 1h in case mirror lists change.
+const artworkCache = new Map<
+  string,
+  { artwork: any; cachedAt: number }
+>()
+const ARTWORK_CACHE_TTL_MS = 60 * 60 * 1000
+
+async function getAudiusArtwork(release: ReleaseRow): Promise<any | undefined> {
+  if (!release.entityId || !release.entityType) return
+  const cacheKey = `${release.entityType}:${release.entityId}`
+  const hit = artworkCache.get(cacheKey)
+  if (hit && Date.now() - hit.cachedAt < ARTWORK_CACHE_TTL_MS) return hit.artwork
+
+  try {
+    const endpoint =
+      release.entityType === 'track'
+        ? `${API_HOST}/v1/full/tracks/${release.entityId}?app_name=ddex`
+        : `${API_HOST}/v1/full/playlists/${release.entityId}?app_name=ddex`
+    const resp = await fetch(endpoint)
+    if (!resp.ok) {
+      console.log('getAudiusArtwork lookup failed', release.entityId, resp.status)
+      return
+    }
+    const j: any = await resp.json()
+    const entity = j.data?.[0] ?? j.data
+    const artwork = entity?.artwork
+    if (artwork) artworkCache.set(cacheKey, { artwork, cachedAt: Date.now() })
+    return artwork
+  } catch (e) {
+    console.log('getAudiusArtwork failed', release.key, e)
+  }
+}
+
+// Batch artwork lookups for a page of releases. Returns a map keyed by
+// release.key → urls[]. Releases without an entityId are skipped.
+async function batchMirrorUrls(
+  releases: ReleaseRow[],
+  size: string = '480x480'
+): Promise<Map<string, string[]>> {
+  const published = releases.filter((r) => r.entityId)
+  const artworks = await Promise.all(
+    published.map((r) => getAudiusArtwork(r))
+  )
+  const out = new Map<string, string[]>()
+  for (let i = 0; i < published.length; i++) {
+    const urls = buildMirrorUrls(artworks[i], size)
+    if (urls.length) out.set(published[i].key, urls)
+  }
+  return out
 }
 
 // Build an Audius URL to serve in place of the S3 asset for a published

--- a/src/views/layout2.tsx
+++ b/src/views/layout2.tsx
@@ -899,6 +899,78 @@ export function Layout2({
               })
           })()
         </script>
+
+        <!--
+          MirrorImage: <img data-mirror-urls='["url1","url2",...]'> tries each
+          URL in order with a 3s per-URL timeout, advancing on timeout or hard
+          error. Necessary because dead/slow Audius content nodes accept the
+          TCP connection but never send data, so the browser stalls until its
+          default 60–90s timeout and onerror never fires.
+        -->
+        <script>
+          ;(function () {
+            var TIMEOUT_MS = 3000
+            var FALLBACK =
+              'data:image/svg+xml;utf8,' +
+              encodeURIComponent(
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200" role="img" aria-label="No media">' +
+                  '<rect width="200" height="200" fill="#e9e3ff"/>' +
+                  '<g stroke="#7f6ad6" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">' +
+                  '<rect x="40" y="50" width="120" height="100" rx="8"/>' +
+                  '<circle cx="75" cy="85" r="10"/>' +
+                  '<path d="M48 138 L88 100 L120 130 L142 110 L152 122"/>' +
+                  '<path d="M58 50 L142 150" stroke="#f94d62"/>' +
+                  '</g>' +
+                  '<text x="100" y="178" font-family="DM Sans,system-ui,sans-serif" font-size="14" fill="#4a5263" text-anchor="middle">No media</text>' +
+                  '</svg>'
+              )
+
+            function wire(img) {
+              var raw = img.getAttribute('data-mirror-urls') || '[]'
+              var urls
+              try {
+                urls = JSON.parse(raw)
+              } catch (e) {
+                urls = []
+              }
+              if (!Array.isArray(urls) || !urls.length) {
+                img.src = FALLBACK
+                return
+              }
+              var idx = 0
+              var timer = null
+              function settle() {
+                if (timer) {
+                  clearTimeout(timer)
+                  timer = null
+                }
+              }
+              function tryNext() {
+                settle()
+                if (idx >= urls.length) {
+                  img.src = FALLBACK
+                  return
+                }
+                img.src = urls[idx]
+                timer = setTimeout(function () {
+                  idx++
+                  tryNext()
+                }, TIMEOUT_MS)
+              }
+              img.addEventListener('load', settle)
+              img.addEventListener('error', function () {
+                settle()
+                idx++
+                tryNext()
+              })
+              tryNext()
+            }
+
+            document
+              .querySelectorAll('img[data-mirror-urls]')
+              .forEach(wire)
+          })()
+        </script>
       </body>
     </html>`
 }


### PR DESCRIPTION
## Summary
Builds the mirror-aware artwork fallback described in audius.co/agents.md (also captured in CLAUDE memory). Dead or slow Audius content nodes accept the TCP connection but never send data, so a plain `<img src="…">` stalls until the browser's 60–90s timeout and `onerror` never fires. With this change every artwork on `/releases` and `/releases/:key` will iterate through `[primary, …mirrors]` with a 3s per-URL budget until one loads.

### Server (`src/server.tsx`)
- `buildMirrorUrls(artwork, size)` — primary URL + each mirror host with the same path.
- `getAudiusArtwork(release)` — fetches `/v1/full/{tracks,playlists}/{id}?app_name=ddex` and returns the full artwork object (with `mirrors`). Backed by a 1h in-memory cache keyed by `entityType:entityId` so a list render doesn't issue one API call per row on every refresh.
- `batchMirrorUrls(rows)` — parallel artwork fetch for a Published page of releases.
- `/releases` and `/releases/:key` render `<img data-mirror-urls='[…]'>` for Published rows. Unpublished rows still use the existing `/release/…` S3 route.

### Client (`src/views/layout2.tsx`)
- Vanilla JS in the shared layout finds every `img[data-mirror-urls]` and runs the timeout-and-advance loop:
  - 3s per-URL timeout — if no `load`/`error` fires by then, move to the next URL.
  - Hard `error` advances immediately.
  - After all URLs are exhausted, falls back to an inline "No media" SVG (via `data:` URL) so the layout doesn't collapse.

### Worst case
3 mirrors × 3s = ~9s before showing the fallback. In practice the primary or first mirror responds immediately.

## Test plan
- [ ] Hit `/releases` — Published rows render artwork; refresh confirms the page render hits the artwork cache (no per-row API calls after the first).
- [ ] Block one of the Audius CDN hosts in DevTools (Network → block request URL) — the image still loads from the next mirror within ~3s.
- [ ] Block all known mirror hosts → "No media" SVG appears, table layout intact.
- [ ] Unpublished rows still render via `/release/…` (S3-backed) and are unaffected.
- [ ] `/releases/:key` detail page same behavior for the 200×200 artwork.
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)