### PR TITLE
Allow re-delivery after a release has been deleted

### DIFF
--- a/src/db/releaseRepo.ts
+++ b/src/db/releaseRepo.ts
@@ -131,13 +131,16 @@ export const releaseRepo = {
       return
     }
 
+    const priorWasDeleted = prior?.status == ReleaseProcessingStatus.Deleted
+
     let status: ReleaseRow['status'] = release.problems.length
       ? ReleaseProcessingStatus.Blocked
       : ReleaseProcessingStatus.PublishPending
 
     // if prior is published and latest version has no deal,
-    // treat as takedown
-    if (prior?.entityId && release.deals.length == 0) {
+    // treat as takedown. Skip when prior was already deleted — a
+    // re-delivery for a deleted release should re-publish, not re-delete.
+    if (!priorWasDeleted && prior?.entityId && release.deals.length == 0) {
       status = ReleaseProcessingStatus.DeletePending
     }
 
@@ -167,6 +170,25 @@ export const releaseRepo = {
     } as Partial<ReleaseRow>
 
     await pgUpsert('releases', 'key', omitEmpty(data))
+
+    // Re-delivery for a previously deleted release: clear stale fields
+    // that point at the now-deleted Audius entity, so the publisher takes
+    // the create path instead of trying to update or re-delete it.
+    // pgUpsert/omitEmpty can't write nulls, so do this as an explicit update.
+    if (priorWasDeleted) {
+      await sql`
+        update releases set
+          "entityId" = null,
+          "entityType" = null,
+          "blockHash" = null,
+          "blockNumber" = null,
+          "publishedAt" = null,
+          "mediaDeletedAt" = null,
+          "publishErrorCount" = 0,
+          "lastPublishError" = null
+        where "key" = ${key}
+      `
+    }
   },
 
   async markPrependArtist(key: string, prependArtist: boolean) {

--- a/src/parseTakedown.test.ts
+++ b/src/parseTakedown.test.ts
@@ -111,4 +111,27 @@ test('crud', async () => {
     expect(rr.soundRecordings[0].title).toBe('Updated Example Song')
     expect(rr.status).toBe(ReleaseProcessingStatus.DeletePending)
   }
+
+  // ----------------
+  // re-delivery after a completed takedown:
+  // a NewReleaseMessage for a Deleted release must reset for re-publish,
+  // not get treated as a takedown again.
+  await releaseRepo.update({
+    key: grid,
+    status: ReleaseProcessingStatus.Deleted,
+    entityType: 'track',
+    entityId: 't1',
+    publishedAt: new Date().toISOString(),
+  })
+
+  {
+    await parseDdexXmlFile(source, 'fixtures/01_delivery.xml')
+    const rr = (await releaseRepo.get(grid))!
+    // status should advance to PublishPending, not bounce back to DeletePending
+    expect(rr.status).toBe(ReleaseProcessingStatus.PublishPending)
+    // stale entity pointers must be cleared so the worker takes the create path
+    expect(rr.entityId).toBeFalsy()
+    expect(rr.entityType).toBeFalsy()
+    expect(rr.publishedAt).toBeFalsy()
+  }
 })


### PR DESCRIPTION
## Summary
- A `NewReleaseMessage` for a release in `Deleted` state was bouncing back to `Deleted`: the no-deal-as-takedown rule fired against the stale `entityId`, and `pgUpsert` + `omitEmpty` never cleared the published-entity fields, so the worker re-ran `deleteRelease` against the dead entity.
- When the new delivery did carry deals, the worker still routed to the *update* path against the dead `entityId` / old user, silently failing.
- Fix: when `prior.status == Deleted`, skip the takedown rewrite and explicitly null `entityId`, `entityType`, `blockHash`, `blockNumber`, `publishedAt`, `mediaDeletedAt`, and the publish-error counters so the worker takes the create path.

## Caveat
- `audiusUser` is *not* cleared on the deleted-row reset. If the re-delivery is meant to land under a different account, the new XML still needs to either resolve to that user via `userRepo.match` or set `audiusUser` explicitly — otherwise the old user gets the new entity.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] `make test` — couldn't run locally (test Postgres container failed to start, no disk space); please run before merging
- New case in `src/parseTakedown.test.ts` covers: deliver → publish → takedown → Deleted → re-deliver should land on `PublishPending` with cleared `entityId`/`entityType`/`publishedAt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)