### PR TITLE
Drop stale purges so rescanAll doesn't undo re-deliveries

### DIFF
--- a/src/db/releaseRepo.ts
+++ b/src/db/releaseRepo.ts
@@ -232,6 +232,17 @@ export const releaseRepo = {
       return
     }
 
+    // Drop stale purges: if the row already has a newer message (e.g. a
+    // re-delivery NewReleaseMessage arrived after this purge was written),
+    // ignore the purge. Otherwise rescanAll-style re-parsing of an old
+    // PurgeReleaseMessage will undo a fresh publish.
+    if (prior.messageTimestamp >= messageTimestamp) {
+      console.log(
+        `skipping purge ${xmlUrl} because ${key} has a newer message`
+      )
+      return
+    }
+
     await releaseRepo.update({
       key,
       status: ReleaseProcessingStatus.DeletePending,

--- a/src/parseTakedown.test.ts
+++ b/src/parseTakedown.test.ts
@@ -87,11 +87,13 @@ test('crud', async () => {
     expect(rr.status).toBe(ReleaseProcessingStatus.Deleted)
   }
 
-  // re-load 03 delete...
+  // re-load 03 delete — stale purge (same messageTimestamp as prior) must
+  // be ignored, otherwise a rescanAll-style replay would undo a later
+  // re-delivery and re-purge a freshly published release.
   {
     await parseDdexXmlFile(source, 'fixtures/03_delete.xml')
     const rr = (await releaseRepo.get(grid))!
-    expect(rr.status).toBe(ReleaseProcessingStatus.DeletePending)
+    expect(rr.status).toBe(ReleaseProcessingStatus.Deleted)
   }
 
   // ----------------
@@ -115,13 +117,15 @@ test('crud', async () => {
   // ----------------
   // re-delivery after a completed takedown:
   // a NewReleaseMessage for a Deleted release must reset for re-publish,
-  // not get treated as a takedown again.
+  // not get treated as a takedown again. Roll messageTimestamp back so
+  // 01_delivery's timestamp is treated as "newer".
   await releaseRepo.update({
     key: grid,
     status: ReleaseProcessingStatus.Deleted,
     entityType: 'track',
     entityId: 't1',
     publishedAt: new Date().toISOString(),
+    messageTimestamp: '2020-01-01T00:00:00Z',
   })
 
   {
@@ -133,5 +137,27 @@ test('crud', async () => {
     expect(rr.entityId).toBeFalsy()
     expect(rr.entityType).toBeFalsy()
     expect(rr.publishedAt).toBeFalsy()
+  }
+
+  // ----------------
+  // stale-purge replay after a re-delivery:
+  // an S3 rescan re-parses the old PurgeReleaseMessage (older
+  // messageTimestamp than the row's current one). It must not flip status
+  // back to DeletePending — that would re-delete the freshly published
+  // entity.
+  await releaseRepo.update({
+    key: grid,
+    status: ReleaseProcessingStatus.Published,
+    entityType: 'track',
+    entityId: 't2',
+    publishedAt: new Date().toISOString(),
+    messageTimestamp: '2099-01-01T00:00:00Z',
+  })
+
+  {
+    await parseDdexXmlFile(source, 'fixtures/03_delete.xml')
+    const rr = (await releaseRepo.get(grid))!
+    expect(rr.status).toBe(ReleaseProcessingStatus.Published)
+    expect(rr.entityId).toBe('t2')
   }
 })


### PR DESCRIPTION
## Summary
- Follow-up to #16. After that fix, a re-delivery for a deleted release *did* re-publish successfully — but the row then bounced back to `Deleted` because the S3 poller's rescanAll re-parsed the original `PurgeReleaseMessage`, and `markForDelete` had no staleness guard.
- Observed in prod for OnChain Music's "Khthon" delivery: publog shows `publishRelease` succeeded with a fresh `trackId`, then a stale purge re-fired `deleteTrack` against it.
- Fix: ignore a purge whose `messageTimestamp` is not newer than the row's current `messageTimestamp` — same shape as the upsert path's existing staleness check.

## Test plan
- [x] `tsc --noEmit` passes
- Existing `parseTakedown.test.ts` updated: re-loading the same purge XML now correctly no-ops instead of round-tripping through `DeletePending`.
- New case: a `Published` row with a future `messageTimestamp` stays `Published` when an older `PurgeReleaseMessage` is re-parsed.
- [ ] `make test` — please run before merging (couldn't run locally, no disk for the test postgres)

🤖 Generated with [Claude Code](https://claude.com/claude-code)