### PR TITLE
Fix DDEX album takedowns

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -86,6 +86,14 @@ UPDATE "s3markers" SET listing_prefix = 'releases/' WHERE bucket = 'ddex-prod-on
 
 The poller uses marker-based incremental polling: each poll continues from the saved marker, processes a page, and saves progress. New releases that sort after the marker are picked up on subsequent polls.
 
+For buckets using the `releases/<id>/` layout, a distributor can add a later
+`purge.xml` inside an existing release folder. That file may sort behind the
+normal marker, so the worker also does a throttled late-XML metadata scan. By
+default it runs every 60 minutes and only fetches XML newer than the stored
+late-scan high-water mark. On first run, it looks back 7 days. Tune this per
+source with `lateXmlScanIntervalMinutes` and `lateXmlInitialLookbackDays`; set
+`lateXmlScanIntervalMinutes` to `0` to disable it for very large buckets.
+
 If you want to delete the state and re-crawl from the start
 
 ```bash

--- a/src/db/releaseRepo.ts
+++ b/src/db/releaseRepo.ts
@@ -107,6 +107,20 @@ export const releaseRepo = {
     return row as ReleaseRow
   },
 
+  async findByReleaseIds(releaseIds: DDEXReleaseIds) {
+    const entries = Object.entries(releaseIds).filter(([, value]) => value)
+
+    for (const [field, value] of entries) {
+      const rows: ReleaseRow[] = await sql`
+        select * from releases
+        where "releaseIds" ->> ${field} = ${value}
+        order by "messageTimestamp" desc
+        limit 1
+      `
+      if (rows[0]) return rows[0]
+    }
+  },
+
   async update(r: Partial<ReleaseRow>) {
     await pgUpdate('releases', 'key', r)
   },
@@ -221,11 +235,13 @@ export const releaseRepo = {
     messageTimestamp: string,
     releaseIds: DDEXReleaseIds
   ) {
-    // here we do PK lookup using the "best" id
-    // but we may need to try to find by all the different releaseIds
-    // if it's not consistent
+    // Try the primary key first, then fall back to any stored releaseId. Some
+    // distributors use different identifiers in purge messages than they used
+    // for the original release delivery.
     const key = releaseRepo.chooseReleaseId(releaseIds)
-    const prior = await releaseRepo.get(key)
+    const prior =
+      (await releaseRepo.get(key)) ||
+      (await releaseRepo.findByReleaseIds(releaseIds))
 
     if (!prior) {
       console.log(`got purge release but no prior ${key}`)
@@ -236,15 +252,19 @@ export const releaseRepo = {
     // re-delivery NewReleaseMessage arrived after this purge was written),
     // ignore the purge. Otherwise rescanAll-style re-parsing of an old
     // PurgeReleaseMessage will undo a fresh publish.
-    if (prior.messageTimestamp >= messageTimestamp) {
+    if (
+      prior.messageTimestamp > messageTimestamp ||
+      (prior.messageTimestamp == messageTimestamp &&
+        prior.status == ReleaseProcessingStatus.Deleted)
+    ) {
       console.log(
-        `skipping purge ${xmlUrl} because ${key} has a newer message`
+        `skipping purge ${xmlUrl} because ${prior.key} has a newer message`
       )
       return
     }
 
     await releaseRepo.update({
-      key,
+      key: prior.key,
       status: ReleaseProcessingStatus.DeletePending,
       source,
       xmlUrl,

--- a/src/parseTakedown.test.ts
+++ b/src/parseTakedown.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, expect, test } from 'vitest'
 
 import { ReleaseProcessingStatus, releaseRepo, userRepo } from './db'
 import { pgMigrate } from './db/migrations'
-import { parseDdexXmlFile } from './parseDelivery'
+import { parseDdexXmlFile, type DDEXRelease } from './parseDelivery'
 import { sources } from './sources'
 
 beforeAll(async () => {
@@ -96,6 +96,22 @@ test('crud', async () => {
     expect(rr.status).toBe(ReleaseProcessingStatus.Deleted)
   }
 
+  // A same-timestamp purge should still delete a published row. The same
+  // timestamp only means stale when the release was already deleted.
+  await releaseRepo.update({
+    key: grid,
+    status: ReleaseProcessingStatus.Published,
+    entityType: 'track',
+    entityId: 't-same-timestamp',
+    messageTimestamp: '2024-04-02T07:00:00Z',
+  })
+
+  {
+    await parseDdexXmlFile(source, 'fixtures/03_delete.xml')
+    const rr = (await releaseRepo.get(grid))!
+    expect(rr.status).toBe(ReleaseProcessingStatus.DeletePending)
+  }
+
   // ----------------
   // no deal as takedown:
   // track is in a published state
@@ -160,4 +176,56 @@ test('crud', async () => {
     expect(rr.status).toBe(ReleaseProcessingStatus.Published)
     expect(rr.entityId).toBe('t2')
   }
+})
+
+test('purge can match a release by a non-key release id', async () => {
+  const source = 'crudTest'
+  const upc = '000000000123'
+  const grid = 'GRIDALT0000000000000000000000000000000000'
+
+  const release: DDEXRelease = {
+    ref: 'R1',
+    title: 'Alternate ID Album',
+    genre: 'Folk',
+    subGenre: 'Indie Folk',
+    releaseDate: '2024-01-01',
+    releaseType: 'Album',
+    releaseIds: {
+      icpn: upc,
+      grid,
+    },
+    isMainRelease: true,
+    problems: [],
+    soundRecordings: [],
+    images: [],
+    deals: [],
+    artists: [{ name: 'DJ Theo', role: 'MainArtist' }],
+    contributors: [],
+    indirectContributors: [],
+    labelName: 'Iron Crown Music',
+  }
+
+  await releaseRepo.upsert(
+    source,
+    'fixtures/alternate_id_delivery.xml',
+    '2024-01-01T00:00:00Z',
+    release
+  )
+  await releaseRepo.update({
+    key: upc,
+    status: ReleaseProcessingStatus.Published,
+    entityType: 'album',
+    entityId: 'album-alt-id',
+  })
+
+  await releaseRepo.markForDelete(
+    source,
+    'fixtures/alternate_id_purge.xml',
+    '2024-01-02T00:00:00Z',
+    { grid }
+  )
+
+  const rr = (await releaseRepo.get(upc))!
+  expect(rr.status).toBe(ReleaseProcessingStatus.DeletePending)
+  expect(rr.xmlUrl).toBe('fixtures/alternate_id_purge.xml')
 })

--- a/src/publishRelease.test.ts
+++ b/src/publishRelease.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, expect, test, vi } from 'vitest'
+
+import { deleteAlbumTracks, fetchAlbumTrackIds } from './publishRelease'
+import { type SourceConfig } from './sources'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('fetchAlbumTrackIds returns track ids from the Audius album', async () => {
+  const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      data: [
+        {
+          tracks: [{ id: 'track-1' }, { id: 'track-2' }, {}],
+        },
+      ],
+    }),
+  } as any)
+
+  const source = { env: 'production' } as SourceConfig
+
+  await expect(fetchAlbumTrackIds(source, 'album-1')).resolves.toEqual([
+    'track-1',
+    'track-2',
+  ])
+  expect(fetchMock).toHaveBeenCalledWith(
+    'https://api.audius.co/v1/full/playlists/album-1',
+    { headers: { accept: 'application/json' } }
+  )
+})
+
+test('deleteAlbumTracks deletes each track in the album', async () => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      data: [
+        {
+          tracks: [{ id: 'track-1' }, { id: 'track-2' }],
+        },
+      ],
+    }),
+  } as any)
+
+  const deleteTrack = vi.fn().mockResolvedValue({})
+  const sdk = {
+    tracks: {
+      deleteTrack,
+    },
+  } as any
+  const source = { env: 'staging' } as SourceConfig
+
+  await deleteAlbumTracks(source, sdk, 'album-1', 'user-1')
+
+  expect(deleteTrack).toHaveBeenNthCalledWith(1, {
+    trackId: 'track-1',
+    userId: 'user-1',
+  })
+  expect(deleteTrack).toHaveBeenNthCalledWith(2, {
+    trackId: 'track-2',
+    userId: 'user-1',
+  })
+})

--- a/src/publishRelease.ts
+++ b/src/publishRelease.ts
@@ -54,8 +54,12 @@ export async function publishValidPendingReleases() {
     const parsed = row
 
     if (row.status == ReleaseProcessingStatus.DeletePending) {
-      // delete
-      deleteRelease(source, row)
+      try {
+        await deleteRelease(source, row)
+      } catch (e: any) {
+        console.log('failed to delete', row.key, e)
+        await releaseRepo.addPublishError(row.key, e)
+      }
     } else if (row.entityId) {
       // update
       if (row.entityType == 'track') {
@@ -403,6 +407,7 @@ export async function deleteRelease(source: SourceConfig, r: ReleaseRow) {
     })
     return onDeleted(result)
   } else if (r.entityType == 'album') {
+    await deleteAlbumTracks(source, sdk, entityId, userId)
     const result = await sdk.albums.deleteAlbum({
       albumId: entityId,
       userId,
@@ -419,6 +424,48 @@ export async function deleteRelease(source: SourceConfig, r: ReleaseRow) {
     })
     return result
   }
+}
+
+export async function deleteAlbumTracks(
+  source: SourceConfig,
+  sdk: ReturnType<typeof getSdk>,
+  albumId: string,
+  userId: string
+) {
+  const trackIds = await fetchAlbumTrackIds(source, albumId)
+
+  for (const trackId of trackIds) {
+    console.log('delete album track', trackId)
+    await sdk.tracks.deleteTrack({
+      trackId,
+      userId,
+    })
+  }
+}
+
+export async function fetchAlbumTrackIds(
+  source: SourceConfig,
+  albumId: string
+) {
+  const apiHost =
+    source.env === 'production'
+      ? 'https://api.audius.co'
+      : 'https://api.staging.audius.co'
+  const resp = await fetch(`${apiHost}/v1/full/playlists/${albumId}`, {
+    headers: { accept: 'application/json' },
+  })
+
+  if (!resp.ok) {
+    throw new Error(`failed to fetch album ${albumId}: ${resp.status}`)
+  }
+
+  const json = await resp.json()
+  const album = json.data?.[0]
+  if (!album) {
+    throw new Error(`failed to fetch album ${albumId}: no album returned`)
+  }
+
+  return (album.tracks || []).map((track: any) => track.id).filter(Boolean)
 }
 
 export function prepareAlbumMetadata(

--- a/src/s3poller.ts
+++ b/src/s3poller.ts
@@ -2,6 +2,7 @@ import {
   DeleteObjectCommand,
   GetObjectCommand,
   ListObjectsCommand,
+  ListObjectsV2Command,
   S3Client,
   S3ClientConfig,
 } from '@aws-sdk/client-s3'
@@ -13,6 +14,9 @@ import { parseDdexXml } from './parseDelivery'
 import { BucketConfig, SourceConfig, sources } from './sources'
 
 type AccessKey = string
+
+const DEFAULT_RELEASES_LATE_XML_SCAN_INTERVAL_MINUTES = 60
+const DEFAULT_RELEASES_LATE_XML_INITIAL_LOOKBACK_DAYS = 7
 
 const s3clients: Record<AccessKey, S3Client> = {}
 
@@ -151,6 +155,90 @@ export async function pollS3Source(
     const existingMarker = await s3markerRepo.get(bucket)
     await s3markerRepo.upsert(bucket, existingMarker, undefined, maxLastModified)
   }
+
+  if (!sourceConfig.rescanAll && listingPrefix === 'releases/') {
+    await scanLateXmlFiles(sourceConfig, client, bucket, listingPrefix)
+  }
+}
+
+async function scanLateXmlFiles(
+  sourceConfig: SourceConfig,
+  client: S3Client,
+  bucket: string,
+  prefix: string
+) {
+  const intervalMinutes =
+    sourceConfig.lateXmlScanIntervalMinutes ??
+    DEFAULT_RELEASES_LATE_XML_SCAN_INTERVAL_MINUTES
+  if (intervalMinutes <= 0) return
+
+  const markerKey = `${bucket}:late_xml_scan`
+  const lastScan = await s3markerRepo.get(markerKey)
+  const lastScanAt = lastScan ? new Date(lastScan) : null
+
+  if (
+    lastScanAt &&
+    Date.now() - lastScanAt.getTime() < intervalMinutes * 60 * 1000
+  ) {
+    return
+  }
+
+  const initialLookbackDays =
+    sourceConfig.lateXmlInitialLookbackDays ??
+    DEFAULT_RELEASES_LATE_XML_INITIAL_LOOKBACK_DAYS
+  const lastModified =
+    (await s3markerRepo.getLastModified(markerKey)) ||
+    new Date(Date.now() - initialLookbackDays * 24 * 60 * 60 * 1000)
+  let maxLastModified = lastModified
+  let continuationToken: string | undefined
+  let pageCount = 0
+
+  do {
+    const result = await client.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      })
+    )
+    const contents = result.Contents || []
+    const changedXml = contents.filter((c) => {
+      const lowerKey = c.Key?.toLowerCase() || ''
+      return (
+        lowerKey.endsWith('.xml') &&
+        !lowerKey.includes('batchcomplete') &&
+        (!lastModified || (c.LastModified && c.LastModified > lastModified))
+      )
+    })
+
+    pageCount++
+    console.log(
+      `late xml scan ${bucket} page=${pageCount} got ${contents.length} files, ${changedXml.length} changed xml files`
+    )
+
+    await processS3Contents(sourceConfig.name, client, bucket, changedXml)
+
+    for (const c of contents) {
+      const lowerKey = c.Key?.toLowerCase() || ''
+      if (
+        lowerKey.endsWith('.xml') &&
+        !lowerKey.includes('batchcomplete') &&
+        c.LastModified &&
+        (!maxLastModified || c.LastModified > maxLastModified)
+      ) {
+        maxLastModified = c.LastModified
+      }
+    }
+
+    continuationToken = result.NextContinuationToken
+  } while (continuationToken)
+
+  await s3markerRepo.upsert(
+    markerKey,
+    new Date().toISOString(),
+    undefined,
+    maxLastModified
+  )
 }
 
 // Helper function to process S3 objects (XML files)

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -33,6 +33,8 @@ export type SourceConfig = BucketConfig & {
   acknowledgementServerUsername?: string
   acknowledgementServerPassword?: string
   rescanAll?: boolean
+  lateXmlScanIntervalMinutes?: number
+  lateXmlInitialLookbackDays?: number
 }
 
 let sourcesFile: SourcesFile


### PR DESCRIPTION
## Summary
- Match purge messages against any stored DDEX release ID, not only the preferred primary key.
- Await and record takedown failures, and delete album tracks before deleting the Audius album wrapper.
- Add a throttled late-XML S3 scan for releases/ buckets so late purge.xml files under old UUID prefixes can be picked up without scanning every release folder each worker loop.
- Document the late XML scan tuning knobs.

## Verification
- git diff --check

Full test run was not available in this environment because npm/tsc are not installed.