### PR TITLE
Recover claimable account retries after partial setup

### DIFF
--- a/src/claimable/createUserPublish.test.ts
+++ b/src/claimable/createUserPublish.test.ts
@@ -1,32 +1,44 @@
 import { afterEach, expect, test, vi } from 'vitest'
 
-const assetRepo = {
-  get: vi.fn(),
-}
-
-const releaseRepo = {
-  get: vi.fn(),
-  upsert: vi.fn(),
-}
-
-const userRepo = {
-  match: vi.fn(),
-  upsert: vi.fn(),
-}
-
-const publogRepo = {
-  log: vi.fn(),
-}
-
-const publishRelease = vi.fn()
-const readAssetWithCaching = vi.fn()
-const findByName = vi.fn()
-const signUp = vi.fn()
-const createHedgehogWalletClient = vi.fn()
-const sdk = vi.fn()
-const createAuthLookupKey = vi.fn()
-const createKey = vi.fn()
-const getEntropyFromLocalStorage = vi.fn()
+const {
+  assetRepo,
+  releaseRepo,
+  userRepo,
+  publogRepo,
+  publishRelease,
+  readAssetWithCaching,
+  findByName,
+  signUp,
+  createHedgehogWalletClient,
+  sdk,
+  createAuthLookupKey,
+  createKey,
+  getEntropyFromLocalStorage,
+} = vi.hoisted(() => ({
+  assetRepo: {
+    get: vi.fn(),
+  },
+  releaseRepo: {
+    get: vi.fn(),
+    upsert: vi.fn(),
+  },
+  userRepo: {
+    match: vi.fn(),
+    upsert: vi.fn(),
+  },
+  publogRepo: {
+    log: vi.fn(),
+  },
+  publishRelease: vi.fn(),
+  readAssetWithCaching: vi.fn(),
+  findByName: vi.fn(),
+  signUp: vi.fn(),
+  createHedgehogWalletClient: vi.fn(),
+  sdk: vi.fn(),
+  createAuthLookupKey: vi.fn(),
+  createKey: vi.fn(),
+  getEntropyFromLocalStorage: vi.fn(),
+}))
 
 vi.mock('../db', () => ({
   assetRepo,

--- a/src/claimable/createUserPublish.test.ts
+++ b/src/claimable/createUserPublish.test.ts
@@ -1,9 +1,89 @@
-import { expect, test } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
+
+const assetRepo = {
+  get: vi.fn(),
+}
+
+const releaseRepo = {
+  get: vi.fn(),
+  upsert: vi.fn(),
+}
+
+const userRepo = {
+  match: vi.fn(),
+  upsert: vi.fn(),
+}
+
+const publogRepo = {
+  log: vi.fn(),
+}
+
+const publishRelease = vi.fn()
+const readAssetWithCaching = vi.fn()
+const findByName = vi.fn()
+const signUp = vi.fn()
+const createHedgehogWalletClient = vi.fn()
+const sdk = vi.fn()
+const createAuthLookupKey = vi.fn()
+const createKey = vi.fn()
+const getEntropyFromLocalStorage = vi.fn()
+
+vi.mock('../db', () => ({
+  assetRepo,
+  releaseRepo,
+  userRepo,
+}))
+
+vi.mock('../db/publogRepo', () => ({
+  publogRepo,
+}))
+
+vi.mock('../publishRelease', () => ({
+  publishRelease,
+}))
+
+vi.mock('../s3poller', () => ({
+  readAssetWithCaching,
+}))
+
+vi.mock('../sources', () => ({
+  sources: {
+    findByName,
+  },
+}))
+
+vi.mock('@audius/sdk', () => ({
+  createHedgehogWalletClient,
+  sdk,
+}))
+
+vi.mock('@audius/hedgehog', () => ({
+  WalletManager: {
+    createAuthLookupKey,
+    getEntropyFromLocalStorage,
+  },
+}))
+
+vi.mock('./hedgehog', () => ({
+  generateRecoveryInfo: vi.fn(),
+  getHedgehog: vi.fn(() => ({
+    signUp,
+    createKey,
+  })),
+}))
 
 import {
   ClaimableHandleRequiredError,
+  ClaimableRecoveryRequiredError,
   defaultClaimableHandle,
+  publishToClaimableAccount,
 } from './createUserPublish'
+import { encodeId } from '../util'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
 
 test('defaultClaimableHandle uses ASCII artist names directly', () => {
   expect(defaultClaimableHandle('DJ Theo')).toBe('DJTheo')
@@ -21,4 +101,125 @@ test('ClaimableHandleRequiredError explains the operator action', () => {
   expect(new ClaimableHandleRequiredError('ОСОБО ТЯЖКИЙ').message).toContain(
     'Set audiusHandle in the UI'
   )
+})
+
+test('retries recover when the remote claimable account and source grant already exist', async () => {
+  const release = {
+    key: 'release-1',
+    source: 'source-1',
+    xmlUrl: 's3://bucket/file.xml',
+    messageTimestamp: '2026-06-08T00:00:00.000Z',
+    artists: [{ name: 'DJ Theo' }],
+    images: [{ ref: 'cover' }],
+    soundRecordings: [],
+    releaseIds: [],
+  }
+
+  releaseRepo.get.mockResolvedValue(release)
+  findByName.mockReturnValue({
+    ddexKey: '0xabc123',
+    env: 'staging',
+    name: 'source-1',
+  })
+  assetRepo.get.mockResolvedValue({
+    xmlUrl: 's3://bucket/file.xml',
+    filePath: '/tmp/cover.jpg',
+    fileName: 'cover.jpg',
+  })
+  readAssetWithCaching.mockResolvedValue(Buffer.from('cover'))
+  userRepo.match.mockResolvedValue(undefined)
+  vi.spyOn(globalThis, 'fetch')
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          id: 42,
+          handle: 'DJTheo',
+          name: 'DJ Theo',
+        },
+      }),
+    } as any)
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          {
+            id: 42,
+            handle: 'DJTheo',
+            name: 'DJ Theo',
+          },
+        ],
+      }),
+    } as any)
+
+  await publishToClaimableAccount('release-1')
+
+  expect(signUp).not.toHaveBeenCalled()
+  expect(userRepo.upsert).toHaveBeenCalledWith({
+    apiKey: '0xabc123',
+    createdAt: expect.any(Date),
+    handle: 'DJTheo',
+    id: encodeId(42),
+    name: 'DJ Theo',
+  })
+  expect(releaseRepo.upsert).toHaveBeenCalledTimes(1)
+  expect(publishRelease).toHaveBeenCalledWith(
+    expect.objectContaining({ ddexKey: '0xabc123' }),
+    release,
+    expect.objectContaining({ audiusUser: encodeId(42) })
+  )
+})
+
+test('retries fail with a recovery-required error when the remote account exists without the source grant', async () => {
+  const release = {
+    key: 'release-1',
+    source: 'source-1',
+    xmlUrl: 's3://bucket/file.xml',
+    messageTimestamp: '2026-06-08T00:00:00.000Z',
+    artists: [{ name: 'DJ Theo' }],
+    images: [{ ref: 'cover' }],
+    soundRecordings: [],
+    releaseIds: [],
+  }
+
+  releaseRepo.get.mockResolvedValue(release)
+  findByName.mockReturnValue({
+    ddexKey: '0xabc123',
+    env: 'staging',
+    name: 'source-1',
+  })
+  assetRepo.get.mockResolvedValue({
+    xmlUrl: 's3://bucket/file.xml',
+    filePath: '/tmp/cover.jpg',
+    fileName: 'cover.jpg',
+  })
+  readAssetWithCaching.mockResolvedValue(Buffer.from('cover'))
+  userRepo.match.mockResolvedValue(undefined)
+  vi.spyOn(globalThis, 'fetch')
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          id: 42,
+          handle: 'DJTheo',
+          name: 'DJ Theo',
+        },
+      }),
+    } as any)
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [],
+      }),
+    } as any)
+
+  await expect(publishToClaimableAccount('release-1')).rejects.toBeInstanceOf(
+    ClaimableRecoveryRequiredError
+  )
+  expect(userRepo.upsert).not.toHaveBeenCalled()
+  expect(publishRelease).not.toHaveBeenCalled()
 })

--- a/src/claimable/createUserPublish.ts
+++ b/src/claimable/createUserPublish.ts
@@ -6,7 +6,7 @@ import { DDEXResource } from '../parseDelivery'
 import { publishRelease } from '../publishRelease'
 import { readAssetWithCaching } from '../s3poller'
 import { sources } from '../sources'
-import { encodeId } from '../util'
+import { encodeId, lowerAscii } from '../util'
 import { WalletManager } from '@audius/hedgehog'
 import { generateRecoveryInfo, getHedgehog } from './hedgehog'
 
@@ -18,6 +18,22 @@ export class ClaimableHandleRequiredError extends Error {
     )
     this.name = 'ClaimableHandleRequiredError'
   }
+}
+
+export class ClaimableRecoveryRequiredError extends Error {
+  constructor() {
+    super(
+      'ClaimableRecoveryRequired: an existing remote claimable account matches this release, ' +
+        'but the source app grant is missing. Restore the grant or link the user before retrying.'
+    )
+    this.name = 'ClaimableRecoveryRequiredError'
+  }
+}
+
+type DiscoveryUser = {
+  encodedUserId: string
+  handle: string
+  name: string
 }
 
 export async function publishToClaimableAccount(releaseId: string) {
@@ -63,12 +79,34 @@ export async function publishToClaimableAccount(releaseId: string) {
   // if not found, create a claimable account
   let encodedUserId = await userRepo.match(source.ddexKey, [artistName])
   if (!encodedUserId) {
-    // Refuse to signUp if the handle is already claimed on Audius — that
-    // produces an orphaned identity row with no audius user (createUser fails
-    // downstream because the handle is taken). Admin can set audiusHandle in
-    // the UI to publish under a different handle.
-    await assertHandleAvailable(handle, source.env || 'staging')
+    const existingUser = await lookupUserByHandle(
+      handle,
+      source.env || 'staging'
+    )
+    if (existingUser) {
+      const grantedUser = await lookupGrantedUserByHandle(
+        source.ddexKey,
+        handle,
+        source.env || 'staging'
+      )
+      if (grantedUser?.encodedUserId === existingUser.encodedUserId) {
+        encodedUserId = existingUser.encodedUserId
+        await userRepo.upsert({
+          id: encodedUserId,
+          apiKey: source.ddexKey,
+          handle: existingUser.handle,
+          name: existingUser.name,
+          createdAt: new Date(),
+        })
+      } else if (lowerAscii(existingUser.name) === lowerAscii(artistName)) {
+        throw new ClaimableRecoveryRequiredError()
+      } else {
+        throw handleClaimedError(handle, source.env || 'staging')
+      }
+    }
+  }
 
+  if (!encodedUserId) {
     // no user: create claimable user
     console.log(`=== creating claimable account for ${artistName}`)
     const hedgehog = getHedgehog()
@@ -168,12 +206,10 @@ export function defaultClaimableHandle(artistName: string) {
   return fromArtist || undefined
 }
 
-/**
- * Throws HandleClaimed if a discovery user already exists with this handle.
- * Caller's error gets surfaced as the release's lastPublishError, prompting
- * the admin to set an audiusHandle override in the UI.
- */
-async function assertHandleAvailable(handle: string, env: string) {
+async function lookupUserByHandle(
+  handle: string,
+  env: string
+): Promise<DiscoveryUser | undefined> {
   const apiHost =
     env === 'production'
       ? 'https://api.audius.co'
@@ -187,11 +223,62 @@ async function assertHandleAvailable(handle: string, env: string) {
       `discovery handle check failed for ${handle}: HTTP ${res.status}`
     )
   }
+  const payload = await res.json()
+  const user = Array.isArray(payload.data) ? payload.data[0] : payload.data
+  if (!user) return
+  return {
+    encodedUserId: encodeId(user.id || user.user_id),
+    handle: user.handle || handle,
+    name: user.name || '',
+  }
+}
+
+async function lookupGrantedUserByHandle(
+  ddexKey: string,
+  handle: string,
+  env: string
+): Promise<DiscoveryUser | undefined> {
+  const apiHost =
+    env === 'production'
+      ? 'https://api.audius.co'
+      : 'https://api.staging.audius.co'
+  const address = ddexKey.replace(/^0x/, '')
+  const normalizedHandle = lowerAscii(handle)
+  const pageSize = 100
+
+  for (let offset = 0; ; offset += pageSize) {
+    const res = await fetch(
+      `${apiHost}/v1/grantees/${address}/users?is_revoked=false&limit=${pageSize}&offset=${offset}`,
+      {
+        headers: { accept: 'application/json' },
+      }
+    )
+    if (!res.ok) {
+      throw new Error(`discovery grant check failed: HTTP ${res.status}`)
+    }
+    const payload = await res.json()
+    const users = payload.data || []
+    const user = users.find(
+      (candidate: any) =>
+        lowerAscii(candidate.handle || '') === normalizedHandle
+    )
+    if (user) {
+      return {
+        encodedUserId: encodeId(user.id || user.user_id),
+        handle: user.handle || handle,
+        name: user.name || '',
+      }
+    }
+    if (users.length < pageSize) return
+  }
+}
+
+function handleClaimedError(handle: string, env: string) {
   const profileUrl =
     env === 'production'
       ? `https://audius.co/${handle}`
       : `https://staging.audius.co/${handle}`
-  throw new Error(
+  return new Error(
     `HandleClaimed: '${handle}' already exists on Audius (${profileUrl}). ` +
       `Set audiusHandle in the UI to publish under a different handle.`
   )

--- a/src/publishRelease.ts
+++ b/src/publishRelease.ts
@@ -2,6 +2,7 @@ import { UploadAlbumRequest, UploadTrackRequest } from '@audius/sdk'
 import Web3 from 'web3'
 import {
   ClaimableHandleRequiredError,
+  ClaimableRecoveryRequiredError,
   publishToClaimableAccount,
 } from './claimable/createUserPublish'
 import {
@@ -49,7 +50,10 @@ export async function publishValidPendingReleases() {
           await publishToClaimableAccount(row.key)
         } catch (e: any) {
           console.log('auto-publish failed', row.key, e)
-          if (e instanceof ClaimableHandleRequiredError) {
+          if (
+            e instanceof ClaimableHandleRequiredError ||
+            e instanceof ClaimableRecoveryRequiredError
+          ) {
             await releaseRepo.addPublishBlock(row.key, e)
           } else {
             await releaseRepo.addPublishError(row.key, e)


### PR DESCRIPTION
## Summary
- recover retries when a matching remote claimable user already exists and the source grant is still present
- surface a specific publish block when the remote user exists but the source grant is missing
- add focused tests for the recovery and recovery-required paths

## Testing
- npm run tsc
- npx vitest run src/claimable/createUserPublish.test.ts
