### PR TITLE
Update artwork on DDEX re-delivery

### DIFF
--- a/src/publishRelease.test.ts
+++ b/src/publishRelease.test.ts
@@ -1,11 +1,76 @@
 import { afterEach, expect, test, vi } from 'vitest'
 
-import { deleteAlbumTracks, fetchAlbumTrackIds } from './publishRelease'
+const { assetRepo, getSdk, readAssetWithCaching, releaseRepo } = vi.hoisted(
+  () => ({
+    assetRepo: {
+      get: vi.fn(),
+    },
+    getSdk: vi.fn(),
+    readAssetWithCaching: vi.fn(),
+    releaseRepo: {
+      update: vi.fn(),
+    },
+  })
+)
+
+vi.mock('./db', () => ({
+  assetRepo,
+  releaseRepo,
+  userRepo: {},
+  ReleaseProcessingStatus: {
+    Blocked: 'Blocked',
+    PublishPending: 'PublishPending',
+    Published: 'Published',
+    Failed: 'Failed',
+    DeletePending: 'DeletePending',
+    Deleted: 'Deleted',
+  },
+}))
+
+vi.mock('./s3poller', () => ({
+  readAssetWithCaching,
+}))
+
+vi.mock('./sdk', () => ({
+  getSdk,
+}))
+
+import {
+  deleteAlbumTracks,
+  fetchAlbumTrackIds,
+  updateAlbum,
+  updateTrack,
+} from './publishRelease'
 import { type SourceConfig } from './sources'
 
 afterEach(() => {
   vi.restoreAllMocks()
+  vi.clearAllMocks()
 })
+
+const source = {
+  name: 'source-1',
+  ddexKey: '0x0000000000000000000000000000000000000001',
+} as SourceConfig
+
+const releaseRow = {
+  key: 'release-1',
+  entityId: 'entity-1',
+  audiusUser: 'user-1',
+  prependArtist: false,
+  useDefaultDeal: false,
+} as any
+
+function mockCoverAsset() {
+  const imageFile = Buffer.from('cover')
+  assetRepo.get.mockResolvedValue({
+    xmlUrl: 's3://bucket/release.xml',
+    filePath: 'images/',
+    fileName: 'cover.jpg',
+  })
+  readAssetWithCaching.mockResolvedValue(imageFile)
+  return imageFile
+}
 
 test('fetchAlbumTrackIds returns track ids from the Audius album', async () => {
   const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
@@ -61,4 +126,91 @@ test('deleteAlbumTracks deletes each track in the album', async () => {
     trackId: 'track-2',
     userId: 'user-1',
   })
+})
+
+test('updateTrack sends the latest cover art file', async () => {
+  const imageFile = mockCoverAsset()
+  const updateTrackMock = vi.fn().mockResolvedValue({ blockHash: '0xabc' })
+  getSdk.mockReturnValue({
+    tracks: {
+      updateTrack: updateTrackMock,
+    },
+  })
+
+  await updateTrack(source, releaseRow, {
+    audiusGenre: 'Electronic',
+    audiusUser: 'user-1',
+    deals: [],
+    images: [{ ref: 'cover' }],
+    releaseDate: '2024-01-01',
+    releaseIds: {},
+    artists: [],
+    soundRecordings: [
+      {
+        ref: 'track-asset',
+        title: 'Track Title',
+        artists: [],
+        contributors: [],
+        indirectContributors: [],
+      },
+    ],
+  } as any)
+
+  expect(assetRepo.get).toHaveBeenCalledWith('source-1', 'release-1', 'cover')
+  expect(readAssetWithCaching).toHaveBeenCalledWith(
+    's3://bucket/release.xml',
+    'images/',
+    'cover.jpg'
+  )
+  expect(updateTrackMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      userId: 'user-1',
+      trackId: 'entity-1',
+      coverArtFile: imageFile,
+      metadata: expect.objectContaining({
+        title: 'Track Title',
+      }),
+    })
+  )
+})
+
+test('updateAlbum sends the latest cover art file', async () => {
+  const imageFile = mockCoverAsset()
+  const updateAlbumMock = vi.fn().mockResolvedValue({ blockHash: '0xabc' })
+  getSdk.mockReturnValue({
+    albums: {
+      updateAlbum: updateAlbumMock,
+    },
+  })
+
+  await updateAlbum(source, releaseRow, {
+    title: 'Album Title',
+    audiusGenre: 'Electronic',
+    audiusUser: 'user-1',
+    deals: [],
+    images: [{ ref: 'cover' }],
+    releaseDate: '2024-01-01',
+    releaseIds: {
+      icpn: '0123456789012',
+    },
+    artists: [],
+    soundRecordings: [],
+  } as any)
+
+  expect(assetRepo.get).toHaveBeenCalledWith('source-1', 'release-1', 'cover')
+  expect(readAssetWithCaching).toHaveBeenCalledWith(
+    's3://bucket/release.xml',
+    'images/',
+    'cover.jpg'
+  )
+  expect(updateAlbumMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      userId: 'user-1',
+      albumId: 'entity-1',
+      coverArtFile: imageFile,
+      metadata: expect.objectContaining({
+        albumName: 'Album Title',
+      }),
+    })
+  )
 })

--- a/src/publishRelease.ts
+++ b/src/publishRelease.ts
@@ -12,7 +12,12 @@ import {
   releaseRepo,
 } from './db'
 import { publogRepo } from './db/publogRepo'
-import { DDEXContributor, DDEXRelease, DDEXResource, DealPayGated } from './parseDelivery'
+import {
+  DDEXContributor,
+  DDEXRelease,
+  DDEXResource,
+  DealPayGated,
+} from './parseDelivery'
 import { readAssetWithCaching } from './s3poller'
 import { getSdk } from './sdk'
 import { SourceConfig, sources } from './sources'
@@ -110,19 +115,16 @@ export async function publishRelease(
 
   const sdk = getSdk(source)
 
-  // read asset file
-  async function resolveFile({ ref }: DDEXResource) {
-    const asset = await assetRepo.get(source.name, releaseRow.key, ref)
-    if (!asset) {
-      throw new Error(`failed to resolve asset ${releaseRow.key} ${ref}`)
-    }
-    return readAssetWithCaching(asset.xmlUrl, asset.filePath, asset.fileName)
-  }
-
-  const imageFile = await resolveFile(release.images[0])
+  const imageFile = await resolveReleaseAssetFile(
+    source,
+    releaseRow,
+    release.images[0]
+  )
 
   const trackFiles = await Promise.all(
-    release.soundRecordings.map((track) => resolveFile(track))
+    release.soundRecordings.map((track) =>
+      resolveReleaseAssetFile(source, releaseRow, track)
+    )
   )
 
   const trackMetadatas = prepareTrackMetadatas(source, releaseRow, release)
@@ -220,11 +222,17 @@ export async function updateTrack(
 ) {
   const sdk = getSdk(source)
   const metas = prepareTrackMetadatas(source, row, release)
+  const imageFile = await resolveReleaseAssetFile(
+    source,
+    row,
+    release.images[0]
+  )
 
   const result = await sdk.tracks.updateTrack({
     userId: release.audiusUser!,
     trackId: row.entityId!,
     metadata: metas[0],
+    coverArtFile: imageFile as any,
   })
 
   await releaseRepo.update({
@@ -380,11 +388,17 @@ export async function updateAlbum(
 ) {
   const meta = prepareAlbumMetadata(source, row, release)
   const sdk = getSdk(source)
+  const imageFile = await resolveReleaseAssetFile(
+    source,
+    row,
+    release.images[0]
+  )
 
   const result = await sdk.albums.updateAlbum({
     userId: release.audiusUser!,
     albumId: row.entityId!,
     metadata: meta,
+    coverArtFile: imageFile as any,
   })
 
   await releaseRepo.update({
@@ -548,4 +562,16 @@ function mapContributor(c: DDEXContributor) {
     name: c.name,
     roles: [c.role!], // todo: does ddex xml have multiple roles for a contributor?
   }
+}
+
+async function resolveReleaseAssetFile(
+  source: SourceConfig,
+  releaseRow: ReleaseRow,
+  { ref }: DDEXResource
+) {
+  const asset = await assetRepo.get(source.name, releaseRow.key, ref)
+  if (!asset) {
+    throw new Error(`failed to resolve asset ${releaseRow.key} ${ref}`)
+  }
+  return readAssetWithCaching(asset.xmlUrl, asset.filePath, asset.fileName)
 }


### PR DESCRIPTION
## Summary
- Resolve the latest delivered cover asset when updating an already-published release
- Pass coverArtFile to both track and album SDK update calls
- Add regression tests for update payloads including refreshed artwork

## Test
- PATH=/Users/ray/.nvm/versions/node/v24.10.0/bin:$PATH make test