### PR TITLE
Avoid duplicate album tracks on publish retry

### DIFF
--- a/scripts/cleanupDuplicateTracks.ts
+++ b/scripts/cleanupDuplicateTracks.ts
@@ -1,0 +1,268 @@
+#!/usr/bin/env npx tsx
+/**
+ * List likely duplicate tracks for a user, and optionally delete explicit ids.
+ *
+ * Dry-run listing:
+ *   HANDLE=<handle> npx tsx scripts/cleanupDuplicateTracks.ts
+ *   USER_ID=<encoded-user-id> npx tsx scripts/cleanupDuplicateTracks.ts
+ *
+ * Explicit deletion:
+ *   USER_ID=<encoded-user-id> DELETE_TRACK_IDS=id1,id2 CONFIRM_DELETE=1 \
+ *     PRIVATE_KEY=<hex> API_KEY=<api-key> npx tsx scripts/cleanupDuplicateTracks.ts
+ *
+ * The script never deletes inferred duplicates. It only deletes the track ids
+ * passed through DELETE_TRACK_IDS after confirming each track belongs to the
+ * selected user.
+ */
+
+import { sdk } from '@audius/sdk'
+import 'dotenv/config'
+
+const API_HOST = process.env.API_HOST || 'https://api.audius.co'
+const APP_NAME = process.env.APP_NAME || 'ddex-duplicate-cleanup'
+
+type ApiTrack = {
+  id?: string
+  title?: string
+  isrc?: string
+  iswc?: string
+  user_id?: string
+  userId?: string
+  user?: {
+    id?: string
+    user_id?: string
+  }
+  isDelete?: boolean
+  is_delete?: boolean
+  createdAt?: string
+  created_at?: string
+  updatedAt?: string
+  updated_at?: string
+  permalink?: string
+  playlistsContainingTrack?: unknown[]
+  playlists_containing_track?: unknown[]
+  albumBacklink?: unknown
+  album_backlink?: unknown
+  ddexReleaseIds?: Record<string, unknown>
+  ddex_release_ids?: Record<string, unknown>
+}
+
+async function main() {
+  const userId = await resolveUserId()
+  const tracks = await fetchUserTracks(userId)
+  const duplicateGroups = findDuplicateGroups(tracks)
+
+  console.log(`Fetched ${tracks.length} tracks for user ${userId}`)
+  if (!duplicateGroups.length) {
+    console.log('No likely duplicate groups found.')
+  } else {
+    console.log(`Found ${duplicateGroups.length} likely duplicate group(s):`)
+    for (const group of duplicateGroups) {
+      printGroup(group)
+    }
+  }
+
+  const deleteTrackIds = parseList(process.env.DELETE_TRACK_IDS)
+  if (!deleteTrackIds.length) return
+
+  if (process.env.CONFIRM_DELETE !== '1') {
+    throw new Error('Set CONFIRM_DELETE=1 to delete explicit track ids')
+  }
+
+  const privateKey = requireEnv('PRIVATE_KEY')
+  const apiKey = await resolveApiKey()
+  const audiusSdk = sdk({
+    apiKey,
+    apiSecret: normalizePrivateKey(privateKey),
+    appName: APP_NAME,
+    environment: 'production',
+  })
+
+  for (const trackId of deleteTrackIds) {
+    const track = await fetchTrack(trackId)
+    const trackUserId = trackOwnerId(track)
+    if (trackUserId !== userId) {
+      throw new Error(
+        `Refusing to delete ${trackId}: owner ${trackUserId || 'unknown'} does not match ${userId}`
+      )
+    }
+
+    console.log(`Deleting ${trackId}: ${track.title || '(untitled)'}`)
+    const result = await audiusSdk.tracks.deleteTrack({ trackId, userId })
+    console.log('Deleted:', result)
+  }
+}
+
+async function resolveUserId() {
+  if (process.env.USER_ID) return process.env.USER_ID
+
+  const handle = process.env.HANDLE
+  if (!handle) {
+    throw new Error('Set HANDLE or USER_ID')
+  }
+
+  const payload = await fetchJson(
+    `${API_HOST}/v1/users/handle/${encodeURIComponent(handle)}?app_name=${APP_NAME}`
+  )
+  const user = Array.isArray(payload.data) ? payload.data[0] : payload.data
+  const userId = user?.id || user?.user_id || user?.userId
+  if (!userId) {
+    throw new Error(`Could not resolve handle: ${handle}`)
+  }
+  return String(userId)
+}
+
+async function fetchUserTracks(userId: string) {
+  const limit = 100
+  const tracks: ApiTrack[] = []
+
+  for (let offset = 0; ; offset += limit) {
+    const payload = await fetchJson(
+      `${API_HOST}/v1/full/users/${encodeURIComponent(
+        userId
+      )}/tracks?app_name=${APP_NAME}&limit=${limit}&offset=${offset}`
+    )
+    const page = Array.isArray(payload.data) ? payload.data : []
+    tracks.push(...page)
+    if (page.length < limit) return tracks
+  }
+}
+
+async function fetchTrack(trackId: string) {
+  const payload = await fetchJson(
+    `${API_HOST}/v1/tracks/${encodeURIComponent(trackId)}?app_name=${APP_NAME}`
+  )
+  const track = Array.isArray(payload.data) ? payload.data[0] : payload.data
+  if (!track) {
+    throw new Error(`Track not found: ${trackId}`)
+  }
+  return track as ApiTrack
+}
+
+async function fetchJson(url: string) {
+  const resp = await fetch(url, { headers: { accept: 'application/json' } })
+  if (!resp.ok) {
+    throw new Error(`Request failed ${resp.status}: ${await resp.text()}`)
+  }
+  return resp.json()
+}
+
+function findDuplicateGroups(tracks: ApiTrack[]) {
+  const groups = new Map<string, ApiTrack[]>()
+
+  for (const track of tracks) {
+    if (track.isDelete || track.is_delete || !track.id) continue
+    const key = duplicateKey(track)
+    const group = groups.get(key) || []
+    group.push(track)
+    groups.set(key, group)
+  }
+
+  return [...groups.values()]
+    .filter((group) => group.length > 1)
+    .map((group) =>
+      group.sort((a, b) =>
+        String(a.createdAt || a.created_at).localeCompare(
+          String(b.createdAt || b.created_at)
+        )
+      )
+    )
+}
+
+function duplicateKey(track: ApiTrack) {
+  return [
+    normalizeText(track.title),
+    normalizeText(track.isrc),
+    normalizeText(track.iswc),
+    normalizeDdexIds(track),
+  ].join('|')
+}
+
+function normalizeText(value: unknown) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+}
+
+function normalizeDdexIds(track: ApiTrack) {
+  const ids = track.ddexReleaseIds || track.ddex_release_ids || {}
+  return Object.keys(ids)
+    .sort()
+    .map((key) => `${key}:${String(ids[key])}`)
+    .join('|')
+}
+
+function printGroup(group: ApiTrack[]) {
+  const title = group[0]?.title || '(untitled)'
+  console.log(`\n${title}`)
+  for (const track of group) {
+    const locations = [
+      hasAlbumBacklink(track) ? 'album' : 'standalone',
+      hasPlaylistContainingTrack(track) ? 'playlist-ref' : '',
+    ].filter(Boolean)
+
+    console.log(
+      [
+        `  ${track.id}`,
+        track.createdAt || track.created_at || 'unknown-created-at',
+        locations.join(',') || 'no-collection-ref',
+        track.permalink || '',
+      ]
+        .filter(Boolean)
+        .join(' | ')
+    )
+  }
+}
+
+function hasAlbumBacklink(track: ApiTrack) {
+  return Boolean(track.albumBacklink || track.album_backlink)
+}
+
+function hasPlaylistContainingTrack(track: ApiTrack) {
+  const playlists =
+    track.playlistsContainingTrack || track.playlists_containing_track
+  return Array.isArray(playlists) && playlists.length > 0
+}
+
+function trackOwnerId(track: ApiTrack) {
+  return String(
+    track.user_id || track.userId || track.user?.id || track.user?.user_id || ''
+  )
+}
+
+async function resolveApiKey() {
+  if (process.env.API_KEY) return process.env.API_KEY
+
+  const sourceName = process.env.SOURCE_NAME
+  if (sourceName) {
+    const { sources } = await import('../src/sources')
+    sources.load()
+    const source = sources.findByName(sourceName)
+    if (source?.ddexKey) return source.ddexKey
+  }
+
+  throw new Error('Set API_KEY or SOURCE_NAME')
+}
+
+function parseList(value: string | undefined) {
+  return (value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function normalizePrivateKey(privateKey: string) {
+  return privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`
+}
+
+function requireEnv(name: string) {
+  const value = process.env[name]
+  if (!value) throw new Error(`Set ${name}`)
+  return value
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -51,6 +51,7 @@ export type ReleaseRow = DDEXRelease & {
   blockHash?: string
   blockNumber?: number
   publishedAt?: string
+  partialTrackIds?: string[] | null
   lastPublishError: string
   publishErrorCount: number
   mediaDeletedAt?: string

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -152,6 +152,7 @@ const steps = [
 
   sql`ALTER TABLE releases ADD COLUMN IF NOT EXISTS "audiusHandle" text;`,
   sql`ALTER TABLE releases ADD COLUMN IF NOT EXISTS "mediaDeletedAt" timestamptz;`,
+  sql`ALTER TABLE releases ADD COLUMN IF NOT EXISTS "partialTrackIds" jsonb;`,
 ]
 
 // poor man's migrate

--- a/src/db/releaseRepo.ts
+++ b/src/db/releaseRepo.ts
@@ -199,6 +199,7 @@ export const releaseRepo = {
           "blockHash" = null,
           "blockNumber" = null,
           "publishedAt" = null,
+          "partialTrackIds" = null,
           "mediaDeletedAt" = null,
           "publishErrorCount" = 0,
           "lastPublishError" = null

--- a/src/publishRelease.test.ts
+++ b/src/publishRelease.test.ts
@@ -1,17 +1,19 @@
 import { afterEach, expect, test, vi } from 'vitest'
 
-const { assetRepo, getSdk, readAssetWithCaching, releaseRepo } = vi.hoisted(
-  () => ({
+const { assetRepo, getSdk, publogRepo, readAssetWithCaching, releaseRepo } =
+  vi.hoisted(() => ({
     assetRepo: {
       get: vi.fn(),
     },
     getSdk: vi.fn(),
+    publogRepo: {
+      log: vi.fn(),
+    },
     readAssetWithCaching: vi.fn(),
     releaseRepo: {
       update: vi.fn(),
     },
-  })
-)
+  }))
 
 vi.mock('./db', () => ({
   assetRepo,
@@ -35,9 +37,14 @@ vi.mock('./sdk', () => ({
   getSdk,
 }))
 
+vi.mock('./db/publogRepo', () => ({
+  publogRepo,
+}))
+
 import {
   deleteAlbumTracks,
   fetchAlbumTrackIds,
+  publishRelease,
   updateAlbum,
   updateTrack,
 } from './publishRelease'
@@ -55,6 +62,7 @@ const source = {
 
 const releaseRow = {
   key: 'release-1',
+  xmlUrl: 's3://bucket/release.xml',
   entityId: 'entity-1',
   audiusUser: 'user-1',
   prependArtist: false,
@@ -70,6 +78,50 @@ function mockCoverAsset() {
   })
   readAssetWithCaching.mockResolvedValue(imageFile)
   return imageFile
+}
+
+function mockReleaseAssets() {
+  assetRepo.get.mockImplementation(async (_source, _releaseId, ref) => ({
+    xmlUrl: 's3://bucket/release.xml',
+    filePath: `${ref}/`,
+    fileName: `${ref}.bin`,
+  }))
+  readAssetWithCaching.mockImplementation(
+    async (_xmlUrl, _filePath, fileName) => Buffer.from(fileName)
+  )
+}
+
+function albumRelease(overrides = {}) {
+  return {
+    title: 'Album Title',
+    audiusGenre: 'Electronic',
+    audiusUser: 'user-1',
+    deals: [],
+    images: [{ ref: 'cover' }],
+    labelName: 'Label',
+    releaseDate: '2024-01-01',
+    releaseIds: {
+      icpn: '0123456789012',
+    },
+    artists: [{ name: 'Artist', role: 'MainArtist' }],
+    soundRecordings: [
+      {
+        ref: 'track-1',
+        title: 'Track One',
+        artists: [],
+        contributors: [],
+        indirectContributors: [],
+      },
+      {
+        ref: 'track-2',
+        title: 'Track Two',
+        artists: [],
+        contributors: [],
+        indirectContributors: [],
+      },
+    ],
+    ...overrides,
+  } as any
 }
 
 test('fetchAlbumTrackIds returns track ids from the Audius album', async () => {
@@ -213,4 +265,125 @@ test('updateAlbum sends the latest cover art file', async () => {
       }),
     })
   )
+})
+
+test('publishRelease persists album track ids after each track publish', async () => {
+  mockReleaseAssets()
+  const uploadTrackMock = vi
+    .fn()
+    .mockResolvedValueOnce({
+      trackId: 'track-id-1',
+      blockHash: '0xtrack1',
+      blockNumber: 10,
+    })
+    .mockResolvedValueOnce({
+      trackId: 'track-id-2',
+      blockHash: '0xtrack2',
+      blockNumber: 11,
+    })
+  const createAlbumMock = vi.fn().mockResolvedValue({
+    albumId: 'album-id-1',
+    blockHash: '0xalbum',
+    blockNumber: 12,
+  })
+  getSdk.mockReturnValue({
+    tracks: {
+      uploadTrack: uploadTrackMock,
+    },
+    albums: {
+      createAlbum: createAlbumMock,
+    },
+  })
+
+  await publishRelease(source, releaseRow, albumRelease())
+
+  expect(uploadTrackMock).toHaveBeenCalledTimes(2)
+  expect(releaseRepo.update).toHaveBeenNthCalledWith(1, {
+    key: 'release-1',
+    partialTrackIds: ['track-id-1'],
+  })
+  expect(releaseRepo.update).toHaveBeenNthCalledWith(2, {
+    key: 'release-1',
+    partialTrackIds: ['track-id-1', 'track-id-2'],
+  })
+  expect(createAlbumMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      trackIds: ['track-id-1', 'track-id-2'],
+      userId: 'user-1',
+    })
+  )
+  expect(releaseRepo.update).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      key: 'release-1',
+      status: 'Published',
+      entityType: 'album',
+      entityId: 'album-id-1',
+      partialTrackIds: null,
+    })
+  )
+})
+
+test('publishRelease reuses partial album track ids on retry', async () => {
+  mockReleaseAssets()
+  const uploadTrackMock = vi.fn()
+  const createAlbumMock = vi.fn().mockResolvedValue({
+    albumId: 'album-id-1',
+    blockHash: '0xalbum',
+    blockNumber: 12,
+  })
+  getSdk.mockReturnValue({
+    tracks: {
+      uploadTrack: uploadTrackMock,
+    },
+    albums: {
+      createAlbum: createAlbumMock,
+    },
+  })
+
+  await publishRelease(
+    source,
+    {
+      ...releaseRow,
+      partialTrackIds: ['track-id-1', 'track-id-2'],
+    },
+    albumRelease()
+  )
+
+  expect(uploadTrackMock).not.toHaveBeenCalled()
+  expect(createAlbumMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      trackIds: ['track-id-1', 'track-id-2'],
+    })
+  )
+})
+
+test('publishRelease keeps partial album track ids when a later track fails', async () => {
+  mockReleaseAssets()
+  const uploadTrackMock = vi
+    .fn()
+    .mockResolvedValueOnce({
+      trackId: 'track-id-1',
+      blockHash: '0xtrack1',
+      blockNumber: 10,
+    })
+    .mockRejectedValueOnce(new Error('track publish failed'))
+  const createAlbumMock = vi.fn()
+  getSdk.mockReturnValue({
+    tracks: {
+      uploadTrack: uploadTrackMock,
+    },
+    albums: {
+      createAlbum: createAlbumMock,
+    },
+  })
+
+  await expect(
+    publishRelease(source, releaseRow, albumRelease())
+  ).rejects.toThrow('track publish failed')
+
+  expect(releaseRepo.update).toHaveBeenCalledWith({
+    key: 'release-1',
+    partialTrackIds: ['track-id-1'],
+  })
+  expect(createAlbumMock).not.toHaveBeenCalled()
 })

--- a/src/publishRelease.ts
+++ b/src/publishRelease.ts
@@ -139,15 +139,20 @@ export async function publishRelease(
 
   // publish album
   if (release.soundRecordings.length > 1) {
-    const uploadAlbumRequest: UploadAlbumRequest = {
+    const trackIds = await publishAlbumTracks(
+      releaseRow,
+      release,
+      imageFile,
+      trackFiles,
+      trackMetadatas
+    )
+
+    const result = await sdk.albums.createAlbum({
       coverArtFile: imageFile as any,
       metadata: prepareAlbumMetadata(source, releaseRow, release),
-      trackFiles: trackFiles as any,
-      trackMetadatas,
+      trackIds,
       userId: release.audiusUser!,
-    }
-
-    const result = await sdk.albums.uploadAlbum(uploadAlbumRequest)
+    })
     console.log('album published', result)
 
     await publogRepo.log({
@@ -165,6 +170,7 @@ export async function publishRelease(
       blockNumber: result.blockNumber,
       blockHash: result.blockHash,
       publishedAt: new Date().toISOString(),
+      partialTrackIds: null,
     })
 
     // media stays in S3 for a grace period after publishing; the
@@ -212,6 +218,71 @@ export async function publishRelease(
     // purgeOldPublishedMedia worker routine reclaims it later.
 
     // todo: poll for result to ensure it's actually created
+  }
+
+  async function publishAlbumTracks(
+    releaseRow: ReleaseRow,
+    release: DDEXRelease,
+    imageFile: Awaited<ReturnType<typeof resolveReleaseAssetFile>>,
+    trackFiles: Awaited<ReturnType<typeof resolveReleaseAssetFile>>[],
+    trackMetadatas: UploadTrackRequest['metadata'][]
+  ) {
+    const partialTrackIds = Array.isArray(releaseRow.partialTrackIds)
+      ? releaseRow.partialTrackIds.slice(0, release.soundRecordings.length)
+      : []
+
+    if (partialTrackIds.length === release.soundRecordings.length) {
+      console.log('using partial album track ids', {
+        releaseKey: releaseRow.key,
+        count: partialTrackIds.length,
+      })
+      return partialTrackIds
+    }
+
+    for (
+      let i = partialTrackIds.length;
+      i < release.soundRecordings.length;
+      i++
+    ) {
+      const trackFile = trackFiles[i]
+      const metadata = trackMetadatas[i]
+      if (!trackFile || !metadata) {
+        throw new Error(
+          `missing album track data for ${releaseRow.key} index ${i}`
+        )
+      }
+
+      const trackResult = await sdk.tracks.uploadTrack({
+        userId: release.audiusUser!,
+        metadata,
+        coverArtFile: imageFile as any,
+        trackFile: trackFile as any,
+      })
+
+      if (!trackResult.trackId) {
+        throw new Error(
+          `album track publish missing trackId for ${releaseRow.key} index ${i}`
+        )
+      }
+
+      partialTrackIds.push(trackResult.trackId)
+      await releaseRepo.update({
+        key: releaseRow.key,
+        partialTrackIds: [...partialTrackIds],
+      })
+      await publogRepo.log({
+        release_id: releaseRow.key,
+        msg: 'album track publish result',
+        extra: {
+          index: i,
+          trackId: trackResult.trackId,
+          blockNumber: trackResult.blockNumber,
+          blockHash: trackResult.blockHash,
+        },
+      })
+    }
+
+    return partialTrackIds
   }
 }
 


### PR DESCRIPTION
## Summary
- persist track ids as album tracks are published
- reuse saved track ids when retrying album creation
- clear saved partial track ids once the album publish succeeds
- add a dry-run duplicate-track cleanup helper that only deletes explicitly supplied track ids after confirmation

## Test
- npm test -- --run src/publishRelease.test.ts

## Note
- Full test suite was not completed locally because the Docker daemon was unavailable, so the DB-backed suites could not start their local Postgres dependency.