### PR TITLE
Fix SDK v15 album create payload

### DIFF
--- a/src/publishRelease.test.ts
+++ b/src/publishRelease.test.ts
@@ -72,13 +72,14 @@ const releaseRow = {
 } as any
 
 function mockCoverAsset() {
-  const imageFile = Buffer.from('cover')
+  const imageBuffer = Buffer.from('cover')
+  const imageFile = { buffer: imageBuffer, name: 'cover.jpg' }
   assetRepo.get.mockResolvedValue({
     xmlUrl: 's3://bucket/release.xml',
     filePath: 'images/',
     fileName: 'cover.jpg',
   })
-  readAssetWithCaching.mockResolvedValue(imageFile)
+  readAssetWithCaching.mockResolvedValue(imageBuffer)
   return imageFile
 }
 
@@ -349,13 +350,21 @@ test('publishRelease persists album track ids after each track publish', async (
     plannedEntityType: 'album',
     plannedEntityId: plannedAlbumId,
   })
-  expect(createAlbumMock).toHaveBeenCalledWith(
+  const albumRequest = createAlbumMock.mock.calls[0][0]
+  expect(albumRequest).toEqual(
     expect.objectContaining({
-      albumId: plannedAlbumId,
-      trackIds: [plannedTrackId1, plannedTrackId2],
       userId: 'user-1',
+      metadata: expect.objectContaining({
+        playlistId: plannedAlbumId,
+        playlistContents: [
+          { trackId: plannedTrackId1, timestamp: expect.any(Number) },
+          { trackId: plannedTrackId2, timestamp: expect.any(Number) },
+        ],
+      }),
     })
   )
+  expect(albumRequest).not.toHaveProperty('albumId')
+  expect(albumRequest).not.toHaveProperty('trackIds')
   expect(releaseRepo.update).toHaveBeenLastCalledWith(
     expect.objectContaining({
       key: 'release-1',
@@ -407,12 +416,20 @@ test('publishRelease reuses partial album track ids on retry', async () => {
   expect(uploadTrackMock).not.toHaveBeenCalled()
   expect(generateTrackIdMock).not.toHaveBeenCalled()
   expect(generatePlaylistIdMock).not.toHaveBeenCalled()
-  expect(createAlbumMock).toHaveBeenCalledWith(
+  const albumRequest = createAlbumMock.mock.calls[0][0]
+  expect(albumRequest).toEqual(
     expect.objectContaining({
-      albumId: 'planned-album-id',
-      trackIds: ['track-id-1', 'track-id-2'],
+      metadata: expect.objectContaining({
+        playlistId: 'planned-album-id',
+        playlistContents: [
+          { trackId: 'track-id-1', timestamp: expect.any(Number) },
+          { trackId: 'track-id-2', timestamp: expect.any(Number) },
+        ],
+      }),
     })
   )
+  expect(albumRequest).not.toHaveProperty('albumId')
+  expect(albumRequest).not.toHaveProperty('trackIds')
 })
 
 test('publishRelease does not mark albums published without a response id', async () => {
@@ -538,12 +555,20 @@ test('publishRelease reuses a planned album id when album creation fails', async
     )
   ).rejects.toThrow('album failed')
 
-  expect(createAlbumMock).toHaveBeenCalledWith(
+  const albumRequest = createAlbumMock.mock.calls[0][0]
+  expect(albumRequest).toEqual(
     expect.objectContaining({
-      albumId: 'planned-album-id',
-      trackIds: ['track-id-1', 'track-id-2'],
+      metadata: expect.objectContaining({
+        playlistId: 'planned-album-id',
+        playlistContents: [
+          { trackId: 'track-id-1', timestamp: expect.any(Number) },
+          { trackId: 'track-id-2', timestamp: expect.any(Number) },
+        ],
+      }),
     })
   )
+  expect(albumRequest).not.toHaveProperty('albumId')
+  expect(albumRequest).not.toHaveProperty('trackIds')
 })
 
 test('publishRelease persists a planned single track id before upload', async () => {

--- a/src/publishRelease.ts
+++ b/src/publishRelease.ts
@@ -2,6 +2,7 @@ import type {
   CreateAlbumMetadata,
   UploadTrackRequest,
 } from '@audius/sdk'
+import { fromBuffer as fileTypeFromBuffer } from 'file-type'
 import Web3 from 'web3'
 import {
   ClaimableHandleRequiredError,
@@ -28,6 +29,24 @@ import { decodeId, encodeId } from './util'
 
 const DEFAULT_TRACK_PRICE = 1.0
 const DEFAULT_ALBUM_PRICE = 5.0
+type SdkNodeFile = {
+  buffer: Buffer
+  name?: string
+  type?: string
+}
+type CachedAssetData =
+  | Awaited<ReturnType<typeof readAssetWithCaching>>
+  | Buffer
+  | Uint8Array
+
+function normalizeAssetBuffer(assetData: CachedAssetData): Buffer {
+  if (Buffer.isBuffer(assetData)) return assetData
+  if (assetData instanceof Uint8Array) return Buffer.from(assetData)
+  return Buffer.isBuffer(assetData.buffer)
+    ? assetData.buffer
+    : Buffer.from(assetData.buffer)
+}
+
 export const DEFAULT_TRACK_DEAL: DealPayGated = {
   audiusDealType: 'PayGated',
   forStream: true,
@@ -153,11 +172,15 @@ export async function publishRelease(
       encodeId(await sdk.playlists.generatePlaylistId())
     )
 
+    const metadata = {
+      ...prepareAlbumMetadata(source, releaseRow, release),
+      playlistId: albumId,
+      playlistContents: buildPlaylistContents(trackIds),
+    }
+
     const result = await sdk.albums.createAlbum({
-      albumId,
       imageFile: imageFile as any,
-      metadata: prepareAlbumMetadata(source, releaseRow, release),
-      trackIds,
+      metadata: metadata as any,
       userId: release.audiusUser!,
     } as any)
     const resultAlbumId = (result as any).albumId || result.playlistId
@@ -395,6 +418,14 @@ function toValidDate(val: string | undefined): Date | undefined {
   if (!val) return undefined
   const d = new Date(val)
   return isNaN(d.getTime()) ? undefined : d
+}
+
+function buildPlaylistContents(trackIds: string[]) {
+  const timestamp = Math.floor(Date.now() / 1000)
+  return trackIds.map((trackId) => ({
+    trackId,
+    timestamp,
+  }))
 }
 
 export function prepareTrackMetadatas(
@@ -713,10 +744,21 @@ async function resolveReleaseAssetFile(
   source: SourceConfig,
   releaseRow: ReleaseRow,
   { ref }: DDEXResource
-) {
+): Promise<SdkNodeFile> {
   const asset = await assetRepo.get(source.name, releaseRow.key, ref)
   if (!asset) {
     throw new Error(`failed to resolve asset ${releaseRow.key} ${ref}`)
   }
-  return readAssetWithCaching(asset.xmlUrl, asset.filePath, asset.fileName)
+  const assetData = await readAssetWithCaching(
+    asset.xmlUrl,
+    asset.filePath,
+    asset.fileName
+  )
+  const buffer = normalizeAssetBuffer(assetData)
+  const detected = await fileTypeFromBuffer(buffer)
+  return {
+    buffer,
+    name: asset.fileName,
+    ...(detected?.mime ? { type: detected.mime } : {}),
+  }
 }

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -1,5 +1,7 @@
+import { createSdkWithServices } from '@audius/sdk'
 import { expect, test, vi } from 'vitest'
 import { getSdk, getSdkNetworkConfig } from './sdk'
+import { encodeId } from './util'
 
 test('getSdkNetworkConfig requires an explicit publishing env', () => {
   expect(() => getSdkNetworkConfig(undefined)).toThrow(
@@ -39,4 +41,60 @@ test('getSdk surfaces unsupported staging publishing writes', () => {
   ).toThrow('staging DDEX publishing is not supported by @audius/sdk v15')
 
   logSpy.mockRestore()
+})
+
+test('SDK v15 accepts the DDEX album create payload shape', async () => {
+  const uploadFile = vi.fn(() => ({
+    start: vi.fn().mockResolvedValue({ orig_file_cid: 'cover-cid' }),
+  }))
+  const manageEntity = vi.fn().mockResolvedValue({
+    blockHash: '0xblock',
+    blockNumber: 1,
+    transactionHash: '0xtx',
+  })
+  const audiusSdk = createSdkWithServices({
+    apiKey: '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
+    apiSecret:
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
+    appName: 'ddex-test',
+    environment: 'production',
+    services: {
+      storage: { uploadFile } as any,
+      entityManager: { manageEntity } as any,
+    },
+  })
+
+  const albumId = encodeId(201)
+  const trackId = encodeId(101)
+  const userId = encodeId(301)
+  const imageFile = {
+    buffer: Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+      'base64'
+    ),
+    name: 'cover.png',
+    type: 'image/png',
+  }
+
+  await expect(
+    audiusSdk.albums.createAlbum({
+      imageFile,
+      metadata: {
+        albumName: 'Album',
+        playlistId: albumId,
+        playlistContents: [{ trackId, timestamp: 1 }],
+      },
+      userId,
+    } as any)
+  ).resolves.toEqual(
+    expect.objectContaining({
+      playlistId: albumId,
+    })
+  )
+  expect(manageEntity).toHaveBeenCalledWith(
+    expect.objectContaining({
+      entityId: 201,
+      userId: 301,
+    })
+  )
 })


### PR DESCRIPTION
## Summary
- Move the planned album id into album metadata as `playlistId`, which is where SDK v15 reads the playlist-backed album id.
- Write album track membership as `playlistContents` metadata instead of the ignored top-level `trackIds`.
- Normalize cached media into SDK NodeFile-style objects with filename and detected MIME type.
- Add a non-mocked SDK v15 regression test for the album create payload shape.

## Testing
- `npm run tsc`
- `npx vitest run src/sdk.test.ts src/publishRelease.test.ts`
- `npx vitest run src/sdk.test.ts`
- `npm test` with a clean local DB