### PR TITLE
Filter SDK update result fields

### DIFF
--- a/src/publishRelease.test.ts
+++ b/src/publishRelease.test.ts
@@ -185,7 +185,11 @@ test('deleteAlbumTracks deletes each track in the album', async () => {
 
 test('updateTrack sends the latest cover art file', async () => {
   const imageFile = mockCoverAsset()
-  const updateTrackMock = vi.fn().mockResolvedValue({ blockHash: '0xabc' })
+  const updateTrackMock = vi.fn().mockResolvedValue({
+    blockHash: '0xabc',
+    blockNumber: 12,
+    transactionHash: '0xtx',
+  })
   getSdk.mockReturnValue({
     tracks: {
       updateTrack: updateTrackMock,
@@ -227,11 +231,26 @@ test('updateTrack sends the latest cover art file', async () => {
       }),
     })
   )
+  const releaseUpdate = releaseRepo.update.mock.calls[0][0]
+  expect(releaseUpdate).toEqual(
+    expect.objectContaining({
+      key: 'release-1',
+      status: 'Published',
+      publishedAt: expect.any(String),
+      blockHash: '0xabc',
+      blockNumber: 12,
+    })
+  )
+  expect(releaseUpdate).not.toHaveProperty('transactionHash')
 })
 
 test('updateAlbum sends the latest cover art file', async () => {
   const imageFile = mockCoverAsset()
-  const updateAlbumMock = vi.fn().mockResolvedValue({ blockHash: '0xabc' })
+  const updateAlbumMock = vi.fn().mockResolvedValue({
+    blockHash: '0xabc',
+    blockNumber: 12,
+    transactionHash: '0xtx',
+  })
   getSdk.mockReturnValue({
     albums: {
       updateAlbum: updateAlbumMock,
@@ -268,6 +287,17 @@ test('updateAlbum sends the latest cover art file', async () => {
       }),
     })
   )
+  const releaseUpdate = releaseRepo.update.mock.calls[0][0]
+  expect(releaseUpdate).toEqual(
+    expect.objectContaining({
+      key: 'release-1',
+      status: 'Published',
+      publishedAt: expect.any(String),
+      blockHash: '0xabc',
+      blockNumber: 12,
+    })
+  )
+  expect(releaseUpdate).not.toHaveProperty('transactionHash')
 })
 
 test('publishRelease persists album track ids after each track publish', async () => {

--- a/src/publishRelease.ts
+++ b/src/publishRelease.ts
@@ -408,7 +408,7 @@ export async function updateTrack(
     key: row.key,
     status: ReleaseProcessingStatus.Published,
     publishedAt: new Date().toISOString(),
-    ...result,
+    ...sdkWriteResultFields(result),
   })
 
   return result
@@ -426,6 +426,18 @@ function buildPlaylistContents(trackIds: string[]) {
     trackId,
     timestamp,
   }))
+}
+
+function sdkWriteResultFields(result: {
+  blockHash?: string
+  blockNumber?: number
+}): Partial<Pick<ReleaseRow, 'blockHash' | 'blockNumber'>> {
+  return {
+    ...(result.blockHash ? { blockHash: result.blockHash } : {}),
+    ...(result.blockNumber !== undefined
+      ? { blockNumber: result.blockNumber }
+      : {}),
+  }
 }
 
 export function prepareTrackMetadatas(
@@ -582,7 +594,7 @@ export async function updateAlbum(
     key: row.key,
     status: ReleaseProcessingStatus.Published,
     publishedAt: new Date().toISOString(),
-    ...result,
+    ...sdkWriteResultFields(result),
   })
 
   return result


### PR DESCRIPTION
## Summary
- Stop spreading opaque SDK update responses into `releaseRepo.update`.
- Persist only release-table fields returned by SDK update calls: `blockHash` and `blockNumber`.
- Add track and album update regressions that include an extra SDK `transactionHash` field and verify it is not sent to the DB update.

## Testing
- `npm run tsc`
- `npx vitest run src/publishRelease.test.ts src/sdk.test.ts`
- `npm test` with a clean local DB