### PR TITLE
Fix DDEX track media publishing

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_TRACK_DEAL,
   prepareTrackMetadatas,
   publishValidPendingReleases,
+  repairTrackMedia,
 } from './src/publishRelease'
 import { clmReport } from './src/reporting/clm_report'
 import { pollForNewLSRFiles } from './src/reporting/lsr_reader'
@@ -304,6 +305,44 @@ program
       }
     }
 
+    process.exit(0)
+  })
+
+program
+  .command('repair-track-media')
+  .description('Re-upload source audio and artwork for an existing published track')
+  .argument('<release_id>', 'release ID to repair')
+  .option('--dry-run', 'Print the planned repair target without writing')
+  .action(async (releaseId, opts) => {
+    const releaseRow = await releaseRepo.get(releaseId)
+    if (!releaseRow) {
+      throw new Error(`Release ID ${releaseId} not found`)
+    }
+    if (releaseRow.entityType != 'track' || !releaseRow.entityId) {
+      throw new Error(`Release ID ${releaseId} must be a published track`)
+    }
+
+    const sourceConfig = sources.findByName(releaseRow.source)!
+    if (opts.dryRun) {
+      console.log('repair-track-media dry run', {
+        releaseId,
+        source: releaseRow.source,
+        trackId: releaseRow.entityId,
+        userId: releaseRow.audiusUser,
+        imageRef: releaseRow.images[0]?.ref,
+        audioRef: releaseRow.soundRecordings[0]?.ref,
+      })
+      process.exit(0)
+    }
+
+    console.log(
+      'repair-track-media',
+      releaseId,
+      releaseRow.source,
+      releaseRow.entityId
+    )
+    const result = await repairTrackMedia(sourceConfig, releaseRow, releaseRow)
+    console.log('repair-track-media result', result)
     process.exit(0)
   })
 

--- a/src/publishRelease.test.ts
+++ b/src/publishRelease.test.ts
@@ -45,6 +45,7 @@ import {
   deleteAlbumTracks,
   fetchAlbumTrackIds,
   publishRelease,
+  repairTrackMedia,
   updateAlbum,
   updateTrack,
 } from './publishRelease'
@@ -92,6 +93,42 @@ function mockReleaseAssets() {
   readAssetWithCaching.mockImplementation(
     async (_xmlUrl, _filePath, fileName) => Buffer.from(fileName)
   )
+}
+
+function mockTrackUploadResponses(suffix = '1') {
+  return {
+    audioUploadResponse: {
+      id: `audio-upload-${suffix}`,
+      status: 'done',
+      orig_file_cid: `orig-audio-cid-${suffix}`,
+      orig_filename: `audio-${suffix}.flac`,
+      results: {
+        320: `track-cid-${suffix}`,
+      },
+      audio_analysis_error_count: 0,
+    },
+    imageUploadResponse: {
+      id: `image-upload-${suffix}`,
+      status: 'done',
+      orig_file_cid: `image-cid-${suffix}`,
+      orig_filename: `cover-${suffix}.jpg`,
+      results: {},
+      audio_analysis_error_count: 0,
+    },
+  }
+}
+
+function mockUploadTrackFiles(
+  ...responses: ReturnType<typeof mockTrackUploadResponses>[]
+) {
+  const uploadTrackFilesMock = vi.fn()
+  for (const response of responses) {
+    uploadTrackFilesMock.mockReturnValueOnce({
+      start: vi.fn().mockResolvedValue(response),
+      abort: vi.fn(),
+    })
+  }
+  return uploadTrackFilesMock
 }
 
 function albumRelease(overrides = {}) {
@@ -244,6 +281,84 @@ test('updateTrack sends the latest cover art file', async () => {
   expect(releaseUpdate).not.toHaveProperty('transactionHash')
 })
 
+test('repairTrackMedia sends source audio and cover art files', async () => {
+  mockReleaseAssets()
+  const updateTrackMock = vi.fn().mockResolvedValue({
+    blockHash: '0xrepair',
+    blockNumber: 13,
+    transactionHash: '0xtx',
+  })
+  getSdk.mockReturnValue({
+    tracks: {
+      updateTrack: updateTrackMock,
+    },
+  })
+
+  await repairTrackMedia(source, releaseRow, {
+    audiusGenre: 'Electronic',
+    audiusUser: 'user-1',
+    deals: [],
+    images: [{ ref: 'cover' }],
+    releaseDate: '2024-01-01',
+    releaseIds: {},
+    artists: [],
+    soundRecordings: [
+      {
+        ref: 'track-asset',
+        title: 'Track Title',
+        artists: [],
+        contributors: [],
+        indirectContributors: [],
+      },
+    ],
+  } as any)
+
+  expect(assetRepo.get).toHaveBeenNthCalledWith(
+    1,
+    'source-1',
+    'release-1',
+    'cover'
+  )
+  expect(assetRepo.get).toHaveBeenNthCalledWith(
+    2,
+    'source-1',
+    'release-1',
+    'track-asset'
+  )
+  expect(updateTrackMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      userId: 'user-1',
+      trackId: 'entity-1',
+      imageFile: expect.objectContaining({
+        buffer: Buffer.from('cover.bin'),
+        name: 'cover.bin',
+      }),
+      audioFile: expect.objectContaining({
+        buffer: Buffer.from('track-asset.bin'),
+        name: 'track-asset.bin',
+      }),
+      metadata: expect.objectContaining({
+        title: 'Track Title',
+      }),
+    })
+  )
+  expect(publogRepo.log).toHaveBeenCalledWith(
+    expect.objectContaining({
+      release_id: 'release-1',
+      msg: 'track media repair result',
+    })
+  )
+  expect(releaseRepo.update).toHaveBeenCalledWith(
+    expect.objectContaining({
+      key: 'release-1',
+      status: 'Published',
+      publishedAt: expect.any(String),
+      blockHash: '0xrepair',
+      blockNumber: 13,
+    })
+  )
+})
+
 test('updateAlbum sends the latest cover art file', async () => {
   const imageFile = mockCoverAsset()
   const updateAlbumMock = vi.fn().mockResolvedValue({
@@ -305,7 +420,10 @@ test('publishRelease persists album track ids after each track publish', async (
   const plannedTrackId1 = encodeId(101)
   const plannedTrackId2 = encodeId(102)
   const plannedAlbumId = encodeId(201)
-  const uploadTrackMock = vi
+  const trackUpload1 = mockTrackUploadResponses('1')
+  const trackUpload2 = mockTrackUploadResponses('2')
+  const uploadTrackFilesMock = mockUploadTrackFiles(trackUpload1, trackUpload2)
+  const publishTrackMock = vi
     .fn()
     .mockResolvedValueOnce({
       trackId: plannedTrackId1,
@@ -329,7 +447,8 @@ test('publishRelease persists album track ids after each track publish', async (
   const generatePlaylistIdMock = vi.fn().mockResolvedValue(201)
   getSdk.mockReturnValue({
     tracks: {
-      createTrack: uploadTrackMock,
+      uploadTrackFiles: uploadTrackFilesMock,
+      publishTrack: publishTrackMock,
       generateTrackId: generateTrackIdMock,
     },
     albums: {
@@ -342,18 +461,23 @@ test('publishRelease persists album track ids after each track publish', async (
 
   await publishRelease(source, releaseRow, albumRelease())
 
-  expect(uploadTrackMock).toHaveBeenCalledTimes(2)
-  expect(uploadTrackMock).toHaveBeenNthCalledWith(
+  expect(uploadTrackFilesMock).toHaveBeenCalledTimes(2)
+  expect(publishTrackMock).toHaveBeenCalledTimes(2)
+  expect(publishTrackMock).toHaveBeenNthCalledWith(
     1,
     expect.objectContaining({
+      audioUploadResponse: trackUpload1.audioUploadResponse,
+      imageUploadResponse: trackUpload1.imageUploadResponse,
       metadata: expect.objectContaining({
         trackId: plannedTrackId1,
       }),
     })
   )
-  expect(uploadTrackMock).toHaveBeenNthCalledWith(
+  expect(publishTrackMock).toHaveBeenNthCalledWith(
     2,
     expect.objectContaining({
+      audioUploadResponse: trackUpload2.audioUploadResponse,
+      imageUploadResponse: trackUpload2.imageUploadResponse,
       metadata: expect.objectContaining({
         trackId: plannedTrackId2,
       }),
@@ -411,7 +535,8 @@ test('publishRelease persists album track ids after each track publish', async (
 
 test('publishRelease reuses partial album track ids on retry', async () => {
   mockReleaseAssets()
-  const uploadTrackMock = vi.fn()
+  const uploadTrackFilesMock = vi.fn()
+  const publishTrackMock = vi.fn()
   const generateTrackIdMock = vi.fn()
   const generatePlaylistIdMock = vi.fn()
   const createAlbumMock = vi.fn().mockResolvedValue({
@@ -421,7 +546,8 @@ test('publishRelease reuses partial album track ids on retry', async () => {
   })
   getSdk.mockReturnValue({
     tracks: {
-      createTrack: uploadTrackMock,
+      uploadTrackFiles: uploadTrackFilesMock,
+      publishTrack: publishTrackMock,
       generateTrackId: generateTrackIdMock,
     },
     albums: {
@@ -443,7 +569,8 @@ test('publishRelease reuses partial album track ids on retry', async () => {
     albumRelease()
   )
 
-  expect(uploadTrackMock).not.toHaveBeenCalled()
+  expect(uploadTrackFilesMock).not.toHaveBeenCalled()
+  expect(publishTrackMock).not.toHaveBeenCalled()
   expect(generateTrackIdMock).not.toHaveBeenCalled()
   expect(generatePlaylistIdMock).not.toHaveBeenCalled()
   const albumRequest = createAlbumMock.mock.calls[0][0]
@@ -464,7 +591,11 @@ test('publishRelease reuses partial album track ids on retry', async () => {
 
 test('publishRelease does not mark albums published without a response id', async () => {
   mockReleaseAssets()
-  const uploadTrackMock = vi
+  const uploadTrackFilesMock = mockUploadTrackFiles(
+    mockTrackUploadResponses('1'),
+    mockTrackUploadResponses('2')
+  )
+  const publishTrackMock = vi
     .fn()
     .mockResolvedValueOnce({
       trackId: 'track-id-1',
@@ -482,7 +613,8 @@ test('publishRelease does not mark albums published without a response id', asyn
   })
   getSdk.mockReturnValue({
     tracks: {
-      createTrack: uploadTrackMock,
+      uploadTrackFiles: uploadTrackFilesMock,
+      publishTrack: publishTrackMock,
       generateTrackId: vi
         .fn()
         .mockResolvedValueOnce(101)
@@ -511,7 +643,11 @@ test('publishRelease keeps partial album track ids when a later track fails', as
   mockReleaseAssets()
   const plannedTrackId1 = encodeId(101)
   const plannedTrackId2 = encodeId(102)
-  const uploadTrackMock = vi
+  const uploadTrackFilesMock = mockUploadTrackFiles(
+    mockTrackUploadResponses('1'),
+    mockTrackUploadResponses('2')
+  )
+  const publishTrackMock = vi
     .fn()
     .mockResolvedValueOnce({
       trackId: plannedTrackId1,
@@ -526,7 +662,8 @@ test('publishRelease keeps partial album track ids when a later track fails', as
     .mockResolvedValueOnce(102)
   getSdk.mockReturnValue({
     tracks: {
-      createTrack: uploadTrackMock,
+      uploadTrackFiles: uploadTrackFilesMock,
+      publishTrack: publishTrackMock,
       generateTrackId: generateTrackIdMock,
     },
     albums: {
@@ -561,7 +698,8 @@ test('publishRelease reuses a planned album id when album creation fails', async
   const createAlbumMock = vi.fn().mockRejectedValue(new Error('album failed'))
   getSdk.mockReturnValue({
     tracks: {
-      createTrack: vi.fn(),
+      uploadTrackFiles: vi.fn(),
+      publishTrack: vi.fn(),
       generateTrackId: vi.fn(),
     },
     albums: {
@@ -604,7 +742,9 @@ test('publishRelease reuses a planned album id when album creation fails', async
 test('publishRelease persists a planned single track id before upload', async () => {
   mockReleaseAssets()
   const plannedTrackId = encodeId(301)
-  const uploadTrackMock = vi.fn().mockResolvedValue({
+  const trackUpload = mockTrackUploadResponses('single')
+  const uploadTrackFilesMock = mockUploadTrackFiles(trackUpload)
+  const publishTrackMock = vi.fn().mockResolvedValue({
     trackId: plannedTrackId,
     blockHash: '0xtrack',
     blockNumber: 20,
@@ -612,13 +752,17 @@ test('publishRelease persists a planned single track id before upload', async ()
   const generateTrackIdMock = vi.fn().mockResolvedValue(301)
   getSdk.mockReturnValue({
     tracks: {
-      createTrack: uploadTrackMock,
+      uploadTrackFiles: uploadTrackFilesMock,
+      publishTrack: publishTrackMock,
       generateTrackId: generateTrackIdMock,
     },
   })
 
   await publishRelease(
-    source,
+    {
+      ...source,
+      placementHosts: 'host-a,host-b',
+    } as SourceConfig,
     {
       ...releaseRow,
       entityId: undefined,
@@ -645,10 +789,20 @@ test('publishRelease persists a planned single track id before upload', async ()
     plannedEntityType: 'track',
     plannedEntityId: plannedTrackId,
   })
-  expect(uploadTrackMock).toHaveBeenCalledWith(
+  expect(uploadTrackFilesMock).toHaveBeenCalledWith(
     expect.objectContaining({
+      fileMetadata: expect.objectContaining({
+        placementHosts: 'host-a,host-b',
+      }),
+    })
+  )
+  expect(publishTrackMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      audioUploadResponse: trackUpload.audioUploadResponse,
+      imageUploadResponse: trackUpload.imageUploadResponse,
       metadata: expect.objectContaining({
         trackId: plannedTrackId,
+        placementHosts: 'host-a,host-b',
       }),
     })
   )
@@ -665,7 +819,9 @@ test('publishRelease persists a planned single track id before upload', async ()
 test('publishRelease seeds planned track ids from prior partial album tracks', async () => {
   mockReleaseAssets()
   const plannedTrackId2 = encodeId(102)
-  const uploadTrackMock = vi.fn().mockResolvedValue({
+  const trackUpload = mockTrackUploadResponses('2')
+  const uploadTrackFilesMock = mockUploadTrackFiles(trackUpload)
+  const publishTrackMock = vi.fn().mockResolvedValue({
     trackId: plannedTrackId2,
     blockHash: '0xtrack2',
     blockNumber: 11,
@@ -674,7 +830,8 @@ test('publishRelease seeds planned track ids from prior partial album tracks', a
   const generateTrackIdMock = vi.fn().mockResolvedValue(102)
   getSdk.mockReturnValue({
     tracks: {
-      createTrack: uploadTrackMock,
+      uploadTrackFiles: uploadTrackFilesMock,
+      publishTrack: publishTrackMock,
       generateTrackId: generateTrackIdMock,
     },
     albums: {
@@ -700,8 +857,10 @@ test('publishRelease seeds planned track ids from prior partial album tracks', a
     key: 'release-1',
     plannedTrackIds: ['track-id-1', plannedTrackId2],
   })
-  expect(uploadTrackMock).toHaveBeenCalledWith(
+  expect(publishTrackMock).toHaveBeenCalledWith(
     expect.objectContaining({
+      audioUploadResponse: trackUpload.audioUploadResponse,
+      imageUploadResponse: trackUpload.imageUploadResponse,
       metadata: expect.objectContaining({
         trackId: plannedTrackId2,
       }),

--- a/src/publishRelease.ts
+++ b/src/publishRelease.ts
@@ -236,7 +236,7 @@ export async function publishRelease(
       audioFile: trackFile as any,
     }
 
-    const result = await sdk.tracks.createTrack(uploadTrackRequest as any)
+    const result = await publishUploadedTrack(sdk, uploadTrackRequest)
     console.log('track published', result)
 
     await publogRepo.log({
@@ -308,7 +308,7 @@ export async function publishRelease(
         async () => encodeId(await sdk.tracks.generateTrackId())
       )
 
-      const trackResult = await sdk.tracks.createTrack({
+      const trackResult = await publishUploadedTrack(sdk, {
         userId: release.audiusUser!,
         metadata: {
           ...metadata,
@@ -343,6 +343,39 @@ export async function publishRelease(
 
     return partialTrackIds
   }
+}
+
+async function publishUploadedTrack(
+  sdk: ReturnType<typeof getSdk>,
+  params: UploadTrackRequest
+) {
+  const { audioFile, imageFile, metadata, onProgress, userId } = params
+  const { audioUploadResponse, imageUploadResponse } =
+    await sdk.tracks
+      .uploadTrackFiles({
+        audioFile,
+        imageFile,
+        fileMetadata: {
+          placementHosts: metadata.placementHosts,
+          previewStartSeconds: metadata.previewStartSeconds,
+        },
+        onProgress,
+      } as any)
+      .start()
+
+  if (!audioUploadResponse) {
+    throw new Error('track audio upload response missing')
+  }
+  if (!imageUploadResponse) {
+    throw new Error('track image upload response missing')
+  }
+
+  return sdk.tracks.publishTrack({
+    userId,
+    metadata,
+    audioUploadResponse,
+    imageUploadResponse,
+  } as any)
 }
 
 async function ensurePlannedEntityId(
@@ -402,6 +435,52 @@ export async function updateTrack(
     trackId: row.entityId!,
     metadata: metas[0] as any,
     imageFile: imageFile as any,
+  })
+
+  await releaseRepo.update({
+    key: row.key,
+    status: ReleaseProcessingStatus.Published,
+    publishedAt: new Date().toISOString(),
+    ...sdkWriteResultFields(result),
+  })
+
+  return result
+}
+
+export async function repairTrackMedia(
+  source: SourceConfig,
+  row: ReleaseRow,
+  release: DDEXRelease
+) {
+  if (!row.entityId) {
+    throw new Error(`release ${row.key} has no Audius track id`)
+  }
+  const soundRecording = release.soundRecordings[0]
+  if (!soundRecording) {
+    throw new Error(`release ${row.key} has no sound recording to repair`)
+  }
+  const image = release.images[0]
+  if (!image) {
+    throw new Error(`release ${row.key} has no image to repair`)
+  }
+
+  const sdk = getSdk(source)
+  const metas = prepareTrackMetadatas(source, row, release)
+  const imageFile = await resolveReleaseAssetFile(source, row, image)
+  const audioFile = await resolveReleaseAssetFile(source, row, soundRecording)
+
+  const result = await sdk.tracks.updateTrack({
+    userId: release.audiusUser!,
+    trackId: row.entityId,
+    metadata: metas[0] as any,
+    imageFile: imageFile as any,
+    audioFile: audioFile as any,
+  } as any)
+
+  await publogRepo.log({
+    release_id: row.key,
+    msg: 'track media repair result',
+    extra: result,
   })
 
   await releaseRepo.update({

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -98,3 +98,65 @@ test('SDK v15 accepts the DDEX album create payload shape', async () => {
     })
   )
 })
+
+test('SDK v15 publishTrack preserves uploaded media metadata', async () => {
+  const manageEntity = vi.fn().mockResolvedValue({
+    blockHash: '0xblock',
+    blockNumber: 1,
+    transactionHash: '0xtx',
+  })
+  const audiusSdk = createSdkWithServices({
+    apiKey: '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
+    apiSecret:
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
+    appName: 'ddex-test',
+    environment: 'production',
+    services: {
+      entityManager: { manageEntity } as any,
+    },
+  })
+
+  const trackId = encodeId(101)
+  const userId = encodeId(301)
+
+  await expect(
+    audiusSdk.tracks.publishTrack({
+      userId,
+      metadata: {
+        genre: 'Electronic',
+        title: 'Track',
+        trackId,
+      },
+      audioUploadResponse: {
+        id: 'audio-upload',
+        status: 'done',
+        orig_file_cid: 'orig-audio-cid',
+        orig_filename: 'audio.mp3',
+        results: { 320: 'track-cid' },
+        audio_analysis_error_count: 0,
+      },
+      imageUploadResponse: {
+        id: 'image-upload',
+        status: 'done',
+        orig_file_cid: 'cover-cid',
+        orig_filename: 'cover.jpg',
+        results: {},
+        audio_analysis_error_count: 0,
+      },
+    } as any)
+  ).resolves.toEqual(
+    expect.objectContaining({
+      trackId,
+    })
+  )
+
+  const metadata = JSON.parse(manageEntity.mock.calls[0][0].metadata)
+  expect(metadata.data).toEqual(
+    expect.objectContaining({
+      cover_art_sizes: 'cover-cid',
+      orig_file_cid: 'orig-audio-cid',
+      orig_filename: 'audio.mp3',
+      track_cid: 'track-cid',
+    })
+  )
+})


### PR DESCRIPTION
## Summary
- replace the DDEX track create path with uploadTrackFiles(...).start() followed by publishTrack(...) so SDK v15 preserves uploaded audio/artwork metadata
- add a repairTrackMedia helper and CLI command to re-upload source audio/artwork for already-published tracks
- add regression coverage for SDK upload metadata preservation, publish-track call shape, and the repair helper

## Verification
- npx vitest run src/sdk.test.ts src/publishRelease.test.ts
- npm run tsc

## Live repair note
- repaired release 5064020035522 / track ZRybk7J in prod from the original DDEX audio and image assets
- verified Audius API now returns artwork, track_cid, orig_file_cid, cover_art_sizes, duration 213, and is_streamable true
