### PR TITLE
Prune unpublished DDEX media by message timestamp

### DIFF
--- a/src/db/releaseRepo.ts
+++ b/src/db/releaseRepo.ts
@@ -324,8 +324,10 @@ export const releaseRepo = {
     `
   },
 
-  // releases that arrived > cutoff ago, never reached Published/Deleted,
-  // and still have their delivered media on disk in S3
+  // releases whose latest delivery message arrived > cutoff ago, never reached
+  // Published/Deleted, and still have their delivered media on disk in S3.
+  // Use messageTimestamp instead of createdAt because re-deliveries update the
+  // DDEX message timestamp while preserving the original row creation time.
   async findStaleUnpublishedWithMedia(cutoff: Date) {
     const rows: ReleaseRow[] = await sql`
       select * from releases
@@ -334,8 +336,8 @@ export const releaseRepo = {
           ${ReleaseProcessingStatus.Published},
           ${ReleaseProcessingStatus.Deleted}
         )
-        and "createdAt" < ${cutoff.toISOString()}
-      order by "createdAt" asc
+        and nullif("messageTimestamp", '')::timestamptz < ${cutoff}
+      order by nullif("messageTimestamp", '')::timestamptz asc
     `
     return rows
   },

--- a/src/purgeOldMedia.test.ts
+++ b/src/purgeOldMedia.test.ts
@@ -1,0 +1,74 @@
+import { beforeAll, expect, test } from 'vitest'
+
+import { releaseRepo } from './db'
+import { pgMigrate } from './db/migrations'
+import { sql } from './db/sql'
+import type { DDEXRelease } from './parseDelivery'
+
+beforeAll(async () => {
+  await pgMigrate()
+})
+
+test('unpublished media pruning uses latest message timestamp', async () => {
+  const recentMessageKey = '999000000001'
+  const staleMessageKey = '999000000002'
+  const keys = [recentMessageKey, staleMessageKey]
+
+  await sql`delete from assets where "releaseId" = any(${keys})`
+  await sql`delete from releases where "key" = any(${keys})`
+
+  await releaseRepo.upsert(
+    'purgeTest',
+    'fixtures/recent_message.xml',
+    '2026-06-25T14:10:42-07:00',
+    makeRelease(recentMessageKey, 'Old Release Date, Recent Message')
+  )
+  await releaseRepo.upsert(
+    'purgeTest',
+    'fixtures/stale_message.xml',
+    '2025-01-01T00:00:00Z',
+    makeRelease(staleMessageKey, 'Stale Message')
+  )
+
+  await sql`
+    update releases
+    set "createdAt" = '2024-01-01T00:00:00Z'
+    where "key" = ${recentMessageKey}
+  `
+  await sql`
+    update releases
+    set "createdAt" = '2026-06-25T00:00:00Z'
+    where "key" = ${staleMessageKey}
+  `
+
+  const rows = await releaseRepo.findStaleUnpublishedWithMedia(
+    new Date('2026-01-01T00:00:00Z')
+  )
+  const staleKeys = rows.map((row) => row.key)
+
+  expect(staleKeys).not.toContain(recentMessageKey)
+  expect(staleKeys).toContain(staleMessageKey)
+})
+
+function makeRelease(key: string, title: string): DDEXRelease {
+  return {
+    ref: 'R1',
+    title,
+    genre: 'Electronic',
+    subGenre: 'Dance',
+    releaseDate: '2020-01-01',
+    releaseType: 'Single',
+    releaseIds: {
+      icpn: key,
+    },
+    isMainRelease: true,
+    problems: [],
+    soundRecordings: [],
+    images: [],
+    deals: [],
+    artists: [{ name: 'Prune Test Artist', role: 'MainArtist' }],
+    contributors: [],
+    indirectContributors: [],
+    labelName: 'Prune Test Label',
+  }
+}

--- a/src/purgeOldMedia.ts
+++ b/src/purgeOldMedia.ts
@@ -16,7 +16,7 @@ export async function purgeOldUnpublishedMedia() {
   const rows = await releaseRepo.findStaleUnpublishedWithMedia(cutoff)
   if (!rows.length) return
   console.log(
-    `purgeOldUnpublishedMedia: ${rows.length} releases older than ${UNPUBLISHED_STALE_AFTER_DAYS}d still hold media`
+    `purgeOldUnpublishedMedia: ${rows.length} release messages older than ${UNPUBLISHED_STALE_AFTER_DAYS}d still hold media`
   )
   for (const row of rows) {
     try {


### PR DESCRIPTION
## Summary
- prune unpublished release media by latest DDEX message timestamp instead of original row creation time
- keep published media pruning unchanged
- add regression coverage for old release dates/old rows with recently received messages

## Test Plan
- DB_URL=postgres://postgres:test@127.0.0.1:40112/postgres npx vitest run src/purgeOldMedia.test.ts
- npm run tsc

## Prod sanity check
- checked unpublished/non-deleted rows with media not yet deleted: 103137 total, 0 empty/malformed message timestamps