### PR TITLE
Use hash ID in MEAD sender example

### DIFF
--- a/src/parseMead.test.ts
+++ b/src/parseMead.test.ts
@@ -69,7 +69,7 @@ test('parses MEAD artist profile updates', async () => {
 test('MEAD sender example: target an authorized artist by Audius user id', async () => {
   await userRepo.upsert({
     apiKey: 'crudTestKey',
-    id: 'artist-user-1',
+    id: '7eP5n',
     handle: 'artistone',
     name: 'Artist One',
     createdAt: new Date(),
@@ -89,7 +89,7 @@ test('MEAD sender example: target an authorized artist by Audius user id', async
       <PartySummary>
         <PartyReference>P-ARTIST-1</PartyReference>
         <ProprietaryId Namespace="AudiusUserId">
-          <Identifier>artist-user-1</Identifier>
+          <Identifier>7eP5n</Identifier>
         </ProprietaryId>
         <PartyName>
           <FullName>
@@ -129,7 +129,7 @@ test('MEAD sender example: target an authorized artist by Audius user id', async
   expect(updates[0]).toMatchObject({
     partyRef: 'P-ARTIST-1',
     artistName: 'Artist One',
-    audiusUser: 'artist-user-1',
+    audiusUser: '7eP5n',
     displayName: 'Artist One Display',
     bio: 'Short artist bio from a standalone MEAD update.',
     profilePicture: {
@@ -143,7 +143,7 @@ test('MEAD sender example: target an authorized artist by Audius user id', async
   const key = artistProfileUpdateRepo.chooseKey('crudTest', xmlUrl, updates[0])
   await expect(artistProfileUpdateRepo.get(key)).resolves.toMatchObject({
     status: ArtistProfileUpdateStatus.PublishPending,
-    audiusUser: 'artist-user-1',
+    audiusUser: '7eP5n',
   })
 })
 


### PR DESCRIPTION
## Summary
- Update the standalone MEAD sender example test to use an Audius hash-ID-shaped user ID.
- Keep the test aligned with the docs clarification that `AudiusUserId` is the API/SDK encoded hash ID, not a placeholder string.

Follow-up to #28 and AudiusProject/apps#14510.

## Test plan
- `git diff --check`
- `DB_URL=postgresql://postgres:test@127.0.0.1:40111/ddex_mead_test npx vitest run src/parseMead.test.ts`